### PR TITLE
Add support to properly trace CPUs frequencies

### DIFF
--- a/devlib/module/cpufreq.py
+++ b/devlib/module/cpufreq.py
@@ -363,3 +363,16 @@ class CpufreqModule(Module):
                 "done"\
                 .format(governor), as_root=True)
 
+    def trace_frequencies(self):
+        """
+        Report current frequencies on trace file
+        """
+        self.target.execute(
+                'FREQS=$(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq); '
+                'CPU=0; for F in $FREQS; do '
+                '   echo "cpu_frequency:        state=$F cpu_id=$CPU" > /sys/kernel/debug/tracing/trace_marker; '
+                '   let CPU++; '
+                'done',
+                as_root=True
+        )
+

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -101,8 +101,14 @@ class FtraceCollector(TraceCollector):
         if self.automark:
             self.mark_start()
         self.target.execute('{} start {}'.format(self.target_binary, self.event_string), as_root=True)
+        if 'cpufreq' in self.target.modules:
+            self.logger.debug('Trace CPUFreq frequencies')
+            self.target.cpufreq.trace_frequencies()
 
     def stop(self):
+        if 'cpufreq' in self.target.modules:
+            self.logger.debug('Trace CPUFreq frequencies')
+            self.target.cpufreq.trace_frequencies()
         self.stop_time = time.time()
         if self.automark:
             self.mark_stop()


### PR DESCRIPTION
This is a couple of simple patches which ensure to always get a trace with a complete description of the CPUs frequencies every time an experiment is executed while the "cpufreq" module is loaded.

Thus, for example, while running under "userspace" governor at a constant frequency, we always get a trace which has CPUs frequencies information.