### PR TITLE
android: fix initialization without android

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -383,13 +383,14 @@ def _initialize_with_android_home(env):
 
 
 def _initialize_without_android_home(env):
-    if which('adb'):
+    adb_full_path = which('adb')
+    if adb_full_path:
         env.adb = 'adb'
     else:
         raise HostError('ANDROID_HOME is not set and adb is not in PATH. '
                         'Have you installed Android SDK?')
     logger.debug('Discovering ANDROID_HOME from adb path.')
-    env.platform_tools = os.path.dirname(env.adb)
+    env.platform_tools = os.path.dirname(adb_full_path)
     env.android_home = os.path.dirname(env.platform_tools)
     _init_common(env)
     return env


### PR DESCRIPTION
In workload automation, utils.android._initialize_without_android_home()
gets android_home from adb's path.  When this code was copied to devlib,
we mistakenly dropped parsing the output of "which" and instead call
os.path.dirname() on "adb", which always returns "" and makes
_initialize_without_android_home() fail.

Make _initialize_without_android_home() parse the output of "which"
again.