### PR TITLE
Instrument: Add channel with ordered sequence

### DIFF
--- a/devlib/instrument/__init__.py
+++ b/devlib/instrument/__init__.py
@@ -14,6 +14,7 @@
 #
 import csv
 import logging
+import collections
 
 from devlib.utils.types import numeric
 
@@ -167,7 +168,7 @@ class Instrument(object):
     def __init__(self, target):
         self.target = target
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.channels = {}
+        self.channels = collections.OrderedDict()
         self.active_channels = []
 
     # channel management


### PR DESCRIPTION
When add channel for power meter with specific order, it also imply the
order with corresponding fields in captured data. So later need read
back the index for channel and use it to reference power data.

So need use ordered dictionary object for channel.

Signed-off-by: Leo Yan <leo.yan@linaro.org>