### PR TITLE
android: add support to pull multiple files using wildcard expressions

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -173,6 +173,15 @@ class AdbConnection(object):
     def pull(self, source, dest, timeout=None):
         if timeout is None:
             timeout = self.timeout
+        # Pull all files matching a wildcard expression
+        if os.path.isdir(dest) and \
+            ('*' in source or '?' in source):
+            command = 'shell ls {}'.format(source)
+            output = adb_command(self.device, command, timeout=timeout)
+            for line in output.splitlines():
+                command = 'pull {} {}'.format(line, dest)
+                adb_command(self.device, command, timeout=timeout)
+            return
         command = 'pull {} {}'.format(source, dest)
         return adb_command(self.device, command, timeout=timeout)
 


### PR DESCRIPTION
The ADB pull command allows only to pull a single file or a whole directory.

This patch adds the required support to pull only a selection of files, from
a target folder, which match a path specified using '*' and/or '?' wildcards.
In this case we first get the list of files on the target, using the
wildcard expansion support provided by the "ls" command, and than we pull
each and every file returned from the previous command.

This operation mode is available only if the 'dest' parameter is a valid
host-side folder.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>