### PR TITLE
ftrace: give more time for a trace to be collected

### DIFF
--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -124,7 +124,7 @@ class FtraceCollector(TraceCollector):
         # The size of trace.dat will depend on how long trace-cmd was running.
         # Therefore timout for the pull command must also be adjusted
         # accordingly.
-        pull_timeout = self.stop_time - self.start_time
+        pull_timeout = 5 * (self.stop_time - self.start_time)
         self.target.pull(self.target_output_file, outfile, timeout=pull_timeout)
         if not os.path.isfile(outfile):
             self.logger.warning('Binary trace not pulled from device.')


### PR DESCRIPTION
The time required to fetch a trace depends not only on it time length but
also on the amount of events collected and the processing power of the
target device. This patch tries to factorise these last two components
into a 5x constant which is good enough to collect a relatively big trace
on a relatively slow device.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>