### PR TITLE
Add shutils support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.orig
 .ropeproject
 *.egg-info
+devlib/bin/scripts/shutils

--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -18,11 +18,21 @@ cpufreq_set_all_frequencies() {
 	done
 }
 
+cpufreq_get_all_frequencies() {
+	$GREP '' /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq | \
+		$SED -e 's|/sys/devices/system/cpu/cpu||' -e 's|/cpufreq/scaling_cur_freq:| |'
+}
+
 cpufreq_set_all_governors() {
 	GOV=$1
 	for CPU in /sys/devices/system/cpu/cpu[0-9]*; do
 		echo $GOV > $CPU/cpufreq/scaling_governor
 	done
+}
+
+cpufreq_get_all_governors() {
+	$GREP '' /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | \
+		$SED -e 's|/sys/devices/system/cpu/cpu||' -e 's|/cpufreq/scaling_governor:| |'
 }
 
 cpufreq_trace_all_frequencies() {
@@ -41,8 +51,14 @@ case $CMD in
 cpufreq_set_all_frequencies)
     cpufreq_set_all_frequencies $*
     ;;
+cpufreq_get_all_frequencies)
+    cpufreq_get_all_frequencies
+    ;;
 cpufreq_set_all_governors)
     cpufreq_set_all_governors $*
+    ;;
+cpufreq_get_all_governors)
+    cpufreq_get_all_governors
     ;;
 cpufreq_trace_all_frequencies)
     cpufreq_trace_all_frequencies $*

--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -7,12 +7,46 @@ BUSYBOX=${BUSYBOX:-__DEVLIB_BUSYBOX__}
 GREP=${GREP:-$BUSYBOX grep}
 SED=${SED:-$BUSYBOX sed}
 
+################################################################################
+# CPUFrequency Utility Functions
+################################################################################
+
+cpufreq_set_all_frequencies() {
+	FREQ=$1
+	for CPU in /sys/devices/system/cpu/cpu[0-9]*; do
+		echo $FREQ > $CPU/cpufreq/scaling_cur_freq
+	done
+}
+
+cpufreq_set_all_governors() {
+	GOV=$1
+	for CPU in /sys/devices/system/cpu/cpu[0-9]*; do
+		echo $GOV > $CPU/cpufreq/scaling_governor
+	done
+}
+
+cpufreq_trace_all_frequencies() {
+	FREQS=$(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq)
+	CPU=0; for F in $FREQS; do
+		echo "cpu_frequency:        state=$F cpu_id=$CPU" > /sys/kernel/debug/tracing/trace_marker
+		CPU=$((CPU + 1))
+	done
+}
 
 ################################################################################
 # Main Function Dispatcher
 ################################################################################
 
 case $CMD in
+cpufreq_set_all_frequencies)
+    cpufreq_set_all_frequencies $*
+    ;;
+cpufreq_set_all_governors)
+    cpufreq_set_all_governors $*
+    ;;
+cpufreq_trace_all_frequencies)
+    cpufreq_trace_all_frequencies $*
+    ;;
 *)
     echo "Command [$CMD] not supported"
     exit -1

--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -1,0 +1,21 @@
+#!__DEVLIB_SHELL__
+
+CMD=$1
+shift
+
+BUSYBOX=${BUSYBOX:-__DEVLIB_BUSYBOX__}
+GREP=${GREP:-$BUSYBOX grep}
+SED=${SED:-$BUSYBOX sed}
+
+
+################################################################################
+# Main Function Dispatcher
+################################################################################
+
+case $CMD in
+*)
+    echo "Command [$CMD] not supported"
+    exit -1
+esac
+
+# vim: tabstop=4 shiftwidth=4

--- a/devlib/module/cpufreq.py
+++ b/devlib/module/cpufreq.py
@@ -349,30 +349,27 @@ class CpufreqModule(Module):
         for cpu in online_cpus:
             self.set_frequency(cpu, freq, exact)
 
-    def set_all_frequencies(self, freq, exact=False):
-        self.target.execute(
-                "for CPU in /sys/devices/system/cpu/cpu[0-9]*; do "\
-                        "echo {} > $CPU/cpufreq/scaling_cur_freq; "\
-                "done"\
-                .format(freq), as_root=True)
+    def set_all_frequencies(self, freq):
+        """
+        Set the specified (minimum) frequency for all the (online) CPUs
+        """
+        return self.target._execute_util(
+                'cpufreq_set_all_frequencies {}'.format(freq),
+                as_root=True)
+
 
     def set_all_governors(self, governor):
-        self.target.execute(
-                "for CPU in /sys/devices/system/cpu/cpu[0-9]*; do "\
-                        "echo {} > $CPU/cpufreq/scaling_governor; "\
-                "done"\
-                .format(governor), as_root=True)
+        """
+        Set the specified governor for all the (online) CPUs
+        """
+        return self.target._execute_util(
+                'cpufreq_set_all_governors {}'.format(governor),
+                as_root=True)
+
 
     def trace_frequencies(self):
         """
         Report current frequencies on trace file
         """
-        self.target.execute(
-                'FREQS=$(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq); '
-                'CPU=0; for F in $FREQS; do '
-                '   echo "cpu_frequency:        state=$F cpu_id=$CPU" > /sys/kernel/debug/tracing/trace_marker; '
-                '   let CPU++; '
-                'done',
-                as_root=True
-        )
+        return self.target._execute_util('cpufreq_trace_all_frequencies', as_root=True)
 

--- a/devlib/module/cpufreq.py
+++ b/devlib/module/cpufreq.py
@@ -357,6 +357,19 @@ class CpufreqModule(Module):
                 'cpufreq_set_all_frequencies {}'.format(freq),
                 as_root=True)
 
+    def get_all_frequencies(self):
+        """
+        Get the current frequency for all the (online) CPUs
+        """
+        output = self.target._execute_util(
+                'cpufreq_get_all_frequencies', as_root=True)
+        frequencies = {}
+        for x in output.splitlines():
+            kv = x.split(' ')
+            if kv[0] == '':
+                break
+            frequencies[kv[0]] = kv[1]
+        return frequencies
 
     def set_all_governors(self, governor):
         """
@@ -366,6 +379,19 @@ class CpufreqModule(Module):
                 'cpufreq_set_all_governors {}'.format(governor),
                 as_root=True)
 
+    def get_all_governors(self):
+        """
+        Get the current governor for all the (online) CPUs
+        """
+        output = self.target._execute_util(
+                'cpufreq_get_all_governors', as_root=True)
+        governors = {}
+        for x in output.splitlines():
+            kv = x.split(' ')
+            if kv[0] == '':
+                break
+            governors[kv[0]] = kv[1]
+        return governors
 
     def trace_frequencies(self):
         """


### PR DESCRIPTION
Some interactive command on the target can be speed up by using a proxy script which runs entirely on the target and return a partially-processed result to the host.

This series introduces the idea to have a utility script deployed on the target which introduces a common base to run complex actions on the target. We use that script whenever we need to access multiple files to build an overall results. That way we can send just one command to the target, wait for one result and than (eventually) post-process that results to build host side python data structures.

The shutils script has been created to relay just on busybox command, thus it should be possible to execute it on all the target supported by devlib.

This script is the base to introduce an optimized support for some time-consuming operations, such as the enumeration of HWMON channels. A patch for that feature will be posted once this code has been reviewed/refined and accepted.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>