### PR TITLE
Add ftrace function profiling

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -44,6 +44,18 @@ cpufreq_trace_all_frequencies() {
 }
 
 ################################################################################
+# FTrace Utility Functions
+################################################################################
+
+ftrace_get_function_stats() {
+    for CPU in $(ls /sys/kernel/debug/tracing/trace_stat | sed 's/function//'); do
+        REPLACE_STRING="s/  Function/\n  Function (CPU$CPU)/"
+        cat /sys/kernel/debug/tracing/trace_stat/function$CPU \
+            | sed "$REPLACE_STRING"
+    done
+}
+
+################################################################################
 # Main Function Dispatcher
 ################################################################################
 
@@ -62,6 +74,9 @@ cpufreq_get_all_governors)
     ;;
 cpufreq_trace_all_frequencies)
     cpufreq_trace_all_frequencies $*
+    ;;
+ftrace_get_function_stats)
+    ftrace_get_function_stats
     ;;
 *)
     echo "Command [$CMD] not supported"

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -47,8 +47,7 @@ class FtraceCollector(TraceCollector):
                  events=None,
                  buffer_size=None,
                  buffer_size_step=1000,
-                 buffer_size_file='/sys/kernel/debug/tracing/buffer_size_kb',
-                 marker_file='/sys/kernel/debug/tracing/trace_marker',
+                 tracing_path='/sys/kernel/debug/tracing',
                  automark=True,
                  autoreport=True,
                  autoview=False,
@@ -58,8 +57,7 @@ class FtraceCollector(TraceCollector):
         self.events = events if events is not None else DEFAULT_EVENTS
         self.buffer_size = buffer_size
         self.buffer_size_step = buffer_size_step
-        self.buffer_size_file = buffer_size_file
-        self.marker_file = marker_file
+        self.tracing_path = tracing_path
         self.automark = automark
         self.autoreport = autoreport
         self.autoview = autoview
@@ -70,6 +68,10 @@ class FtraceCollector(TraceCollector):
         self.stop_time = None
         self.event_string = _build_trace_events(self.events)
         self._reset_needed = True
+
+        # Setup tracing paths
+        self.buffer_size_file         = self.target.path.join(self.tracing_path, 'buffer_size_kb')
+        self.marker_file              = self.target.path.join(self.tracing_path, 'trace_marker')
 
         self.host_binary = which('trace-cmd')
         self.kernelshark = which('kernelshark')


### PR DESCRIPTION
NOTE: this series depends on the "add_shutils_support" series, actually the first three patches are from that series. Thus, merge it only *after* the shutils series has been accepted.

This series add support for kernel function profiling using FTrace.
The user can specify a set of functions to profile when ftrace is used.
The collection of results from different CPUs is accelerated using the shutils script to aggregate data from all the CPUs available in the system.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>