### PR TITLE
FTrace: optional function and events

### DIFF
--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -125,9 +125,9 @@ class FtraceCollector(TraceCollector):
         self.start_time = time.time()
         if self._reset_needed:
             self.reset()
+        self.target.execute('{} start {}'.format(self.target_binary, self.event_string), as_root=True)
         if self.automark:
             self.mark_start()
-        self.target.execute('{} start {}'.format(self.target_binary, self.event_string), as_root=True)
         if 'cpufreq' in self.target.modules:
             self.logger.debug('Trace CPUFreq frequencies')
             self.target.cpufreq.trace_frequencies()

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -75,11 +75,12 @@ class FtraceCollector(TraceCollector):
         self.host_binary = None
         self.start_time = None
         self.stop_time = None
-        self.event_string = _build_trace_events(self.events)
+        self.event_string = None
         self.function_string = None
         self._reset_needed = True
 
         # Setup tracing paths
+        self.available_events_file    = self.target.path.join(self.tracing_path, 'available_events')
         self.available_functions_file = self.target.path.join(self.tracing_path, 'available_filter_functions')
         self.buffer_size_file         = self.target.path.join(self.tracing_path, 'buffer_size_kb')
         self.current_tracer_file      = self.target.path.join(self.tracing_path, 'current_tracer')
@@ -103,6 +104,32 @@ class FtraceCollector(TraceCollector):
             if not self.target.is_installed('trace-cmd'):
                 raise TargetError('No trace-cmd found on device and no_install=True is specified.')
             self.target_binary = 'trace-cmd'
+
+        # Validate required events to be traced
+        available_events = self.target.execute(
+                'cat {}'.format(self.available_events_file)).splitlines()
+        selected_events = []
+        for event in self.events:
+            # Convert globs supported by FTrace into valid regexp globs
+            _event = event
+            if event[0] != '*':
+                _event = '*' + event
+            event_re = re.compile(_event.replace('*', '.*'))
+            # Select events matching the required ones
+            if len(filter(event_re.match, available_events)) == 0:
+                message = 'Event [{}] not available for tracing'.format(event)
+                if strict:
+                    raise TargetError(message)
+                self.target.logger.warning(message)
+            else:
+                selected_events.append(event)
+        # If function profiling is enabled we always need at least one event.
+        # Thus, if not other events have been specified, try to add at least
+        # a tracepoint which is always available and possibly triggered few
+        # times.
+        if self.functions and len(selected_events) == 0:
+            selected_events = ['sched_wakeup_new']
+        self.event_string = _build_trace_events(selected_events)
 
         # Check for function tracing support
         if self.functions:

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -240,7 +240,7 @@ class FtraceCollector(TraceCollector):
         self.logger.debug("FTrace stats output [%s]...", outfile)
         with open(outfile, 'w') as fh:
            json.dump(function_stats, fh, indent=4)
-        self.logger.info("FTrace function stats save in [%s]", outfile)
+        self.logger.debug("FTrace function stats save in [%s]", outfile)
 
         return function_stats
 


### PR DESCRIPTION
This series adds the support to have a single set of trace events and profile functions to be used with kernel which supports only some of these events. At FTrace initialization time we check which tracepoints/functions are available in the target kernel and enable only those. Not available tracepoints/functions are logged and reported to the user.

The first patch fixes a small bug related to trace marker injection.