### PR TITLE
ssh: add possibility to run command in background as root

### DIFF
--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -177,10 +177,12 @@ class SshConnection(object):
         except EOF:
             raise TargetError('Connection lost.')
 
-    def background(self, command, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
+    def background(self, command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, as_root=False):
         try:
             port_string = '-p {}'.format(self.port) if self.port else ''
             keyfile_string = '-i {}'.format(self.keyfile) if self.keyfile else ''
+            if as_root:
+                command = "sudo -- sh -c '{}'".format(command)
             command = '{} {} {} {}@{} {}'.format(ssh, keyfile_string, port_string, self.username, self.host, command)
             logger.debug(command)
             if self.password:


### PR DESCRIPTION
Executing a command as root was not possible when running it in background.
This is done in a similar way as with a standard execute call.

This was also a bug in ssh.py because if you tried to run a background command
on the target, the background function in target.py was passing the as_root
parameter which was not present in ssh.py.