### PR TITLE
Fix cgroups noprefix

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -62,12 +62,26 @@ ftrace_get_function_stats() {
 ################################################################################
 
 cgroups_get_attributes() {
-	[[ $# -eq 2 ]] || exit -1
+	test $# -eq 2 || exit -1
 	CGROUP="$1"
 	CONTROLLER="$2"
-	$GREP '' $CGROUP/* | \
-		$GREP "$CONTROLLER\." | \
-		$SED -e "s|$CONTROLLER\.||" -e "s|$CGROUP/||"
+	# Check if controller is mounted with "noprefix" option, which is quite
+	# common on Android for backward compatibility
+	ls $CGROUP/$CONTROLLER\.* 2>&1 >/dev/null
+	if [ $? -eq 0 ]; then
+		# no "noprefix" option, attributes format is:
+		#   mnt_point/controller.attribute_name
+		$GREP '' $CGROUP/* | \
+			$GREP "$CONTROLLER\." | \
+			$SED -e "s|$CONTROLLER\.||" -e "s|$CGROUP/||"
+	else
+		# "noprefix" option, attribute format is:
+		#   mnt_point/attribute_name
+		$GREP '' $(\
+			$FIND $CGROUP -type f -maxdepth 1 |
+			$GREP -v -e ".*tasks" -e ".*cgroup\..*") | \
+		$SED "s|$CGROUP/||"
+	fi
 }
 
 cgroups_run_into() {

--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -4,6 +4,7 @@ CMD=$1
 shift
 
 BUSYBOX=${BUSYBOX:-__DEVLIB_BUSYBOX__}
+FIND=${FIND:-$BUSYBOX find}
 GREP=${GREP:-$BUSYBOX grep}
 SED=${SED:-$BUSYBOX sed}
 
@@ -69,6 +70,71 @@ cgroups_get_attributes() {
 		$SED -e "s|$CONTROLLER\.||" -e "s|$CGROUP/||"
 }
 
+cgroups_run_into() {
+
+	# Control groups mount point
+	CGMOUNT=${CGMOUNT:-/sys/fs/cgroup/devlib_*}
+	# The control group we want to run into
+	CGP=${1}
+	# The command to run
+	CMD=${2}
+
+	# Execution under root CGgroup
+	if [ "x/" == "x$CGP" ]; then
+
+	  $FIND $CGMOUNT -type d -maxdepth 0 | \
+	  while read CGPATH; do
+		# Move this shell into that control group
+		echo $$ > $CGPATH/cgroup.procs
+		echo "Moving task into root CGroup ($CGPATH)"
+	  done
+
+	# Execution under specified CGroup
+	else
+
+	  # Check if the required CGroup exists
+	  $FIND $CGMOUNT -type d -mindepth 1 | \
+	  $GREP "$CGP" &>/dev/null
+	  if [ $? -ne 0 ]; then
+		echo "ERROR: could not find any $CGP cgroup under $CGMOUNT"
+		exit 1
+	  fi
+
+	  $FIND $CGMOUNT -type d -mindepth 1 | \
+	  $GREP "$CGP" | \
+	  while read CGPATH; do
+		  # Move this shell into that control group
+		  echo $$ > $CGPATH/cgroup.procs
+		  echo "Moving task into $CGPATH"
+	  done
+
+	fi
+
+	# Execute the command
+	$CMD
+}
+
+cgroups_tasks_move() {
+	SRC_GRP=${1}
+	DST_GRP=${2}
+	GREP_EXCLUSE=${3:-''}
+
+	cat $SRC_GRP/tasks | while read TID; do
+	  echo $TID > $DST_GRP/cgroup.procs
+	done
+
+	[ "$GREP_EXCLUSE" = "" ] && exit 0
+
+	PIDS=`ps | $GREP "$GREP_EXCLUSE" | awk '{print $2}'`
+	PIDS=`echo $PIDS`
+	echo "PIDs to save: [$PIDS]"
+	for TID in $PIDS; do
+	  CMDLINE=`cat /proc/$TID/cmdline`
+	  echo "$TID : $CMDLINE"
+	  echo $TID > $SRC_GRP/cgroup.procs
+	done
+}
+
 ################################################################################
 # Main Function Dispatcher
 ################################################################################
@@ -91,6 +157,12 @@ cpufreq_trace_all_frequencies)
     ;;
 cgroups_get_attributes)
 	cgroups_get_attributes $*
+	;;
+cgroups_run_into)
+    cgroups_run_into $*
+    ;;
+cgroups_tasks_move)
+	cgroups_tasks_move $*
 	;;
 ftrace_get_function_stats)
     ftrace_get_function_stats

--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -90,8 +90,9 @@ cgroups_run_into() {
 	CGMOUNT=${CGMOUNT:-/sys/fs/cgroup/devlib_*}
 	# The control group we want to run into
 	CGP=${1}
+	shift 1
 	# The command to run
-	CMD=${2}
+	CMD="${@}"
 
 	# Execution under root CGgroup
 	if [ "x/" == "x$CGP" ]; then
@@ -125,7 +126,8 @@ cgroups_run_into() {
 	fi
 
 	# Execute the command
-	$CMD
+	exec $CMD
+
 }
 
 cgroups_tasks_move() {

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -104,7 +104,8 @@ class Controller(object):
     def list_all(self):
         self.logger.debug('Listing groups for %s controller', self.kind)
         output = self.target.execute('{} find {} -type d'\
-                .format(self.target.busybox, self.mount_point))
+                .format(self.target.busybox, self.mount_point),
+                as_root=True)
         cgroups = []
         for cg in output.splitlines():
             cg = cg.replace(self.mount_point + '/', '/')
@@ -162,7 +163,7 @@ class CGroup(object):
     def exists(self):
         try:
             self.target.execute('[ -d {0} ]'\
-                .format(self.directory))
+                .format(self.directory), as_root=True)
             return True
         except TargetError:
             return False
@@ -176,7 +177,8 @@ class CGroup(object):
                 self.directory)
         output = self.target._execute_util(
                     'cgroups_get_attributes {} {}'.format(
-                    self.directory, self.controller.kind))
+                    self.directory, self.controller.kind),
+                    as_root=True)
         for res in output.splitlines():
             attr = res.split(':')[0]
             value = res.split(':')[1]

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -275,3 +275,22 @@ class CgroupsModule(Module):
             return None
         return self.controllers[kind]
 
+    def run_into(self, cgroup, cmdline):
+        """
+        Run the specified command into the specified CGroup
+        """
+        return self.target._execute_util(
+            'cgroups_run_into {} {}'.format(cgroup, cmdline),
+            as_root=True)
+
+
+    def cgroups_tasks_move(self, srcg, dstg, exclude=''):
+        """
+        Move all the tasks from the srcg CGroup to the dstg one.
+        A regexps of tasks names can be used to defined tasks which should not
+        be moved.
+        """
+        return self.target._execute_util(
+            'cgroups_tasks_move {} {} {}'.format(srcg, dstg, exclude),
+            as_root=True)
+

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -34,6 +34,7 @@ class Controller(object):
         self.mount_name = 'devlib_'+kind
         self.kind = kind
         self.target = None
+        self._noprefix = False
 
         self.logger = logging.getLogger('cgroups.'+self.kind)
         self.mount_point = None
@@ -68,8 +69,15 @@ class Controller(object):
                             self.mount_point),
                             as_root=True)
 
-        self.logger.debug('Controller %s mounted under: %s',
-            self.kind, self.mount_point)
+        # Check if this controller uses "noprefix" option
+        output = target.execute('mount | grep "{} "'.format(self.mount_name))
+        if 'noprefix' in output:
+            self._noprefix = True
+            # self.logger.debug('Controller %s using "noprefix" option',
+            #                   self.kind)
+
+        self.logger.debug('Controller %s mounted under: %s (noprefix=%s)',
+            self.kind, self.mount_point, self._noprefix)
 
         # Mark this contoller as available
         self.target = target

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -235,7 +235,11 @@ class CgroupsModule(Module):
 
     @staticmethod
     def probe(target):
-        return target.config.has('cgroups') and target.is_rooted
+        if not target.is_rooted:
+            return False
+        if target.file_exists('/proc/cgroups'):
+            return True
+        return target.config.has('cgroups')
 
     def __init__(self, target):
         super(CgroupsModule, self).__init__(target)


### PR DESCRIPTION
CGroups controller can be mounted by specifying a "noprefix" option, in which case attribute names are named according to this template:
       <mountpoint>/<attribute_name>
instead of the (more recent) naming schema using:
       <mountpoint>/<contoller_name>.<attribute_name>
    
For example, Android uses the old format for backward compatibility with user-space. Thus, it's possible in general to work on a target system where some controller are mounted "noprefix" while others not.

This patchset adds a set of updates which allows to use the proper attributes naming schema based on how the controller has been mounted.