### PR TITLE
Cgroup fix setup

### DIFF
--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -231,6 +231,7 @@ CgroupSubsystemEntry = namedtuple('CgroupSubsystemEntry', 'name hierarchy num_cg
 class CgroupsModule(Module):
 
     name = 'cgroups'
+    stage = 'setup'
     cgroup_root = '/sys/fs/cgroup'
 
     @staticmethod

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -216,6 +216,9 @@ class Target(object):
         for host_exe in (executables or []):  # pylint: disable=superfluous-parens
             self.install(host_exe)
 
+        # Initialize modules which requires Buxybox (e.g. shutil dependent tasks)
+        self._update_modules('setup')
+
     def reboot(self, hard=False, connect=True, timeout=180):
         if hard:
             if not self.has('hard_reset'):


### PR DESCRIPTION
Shutil scripts requires a valid busybox path which is defined after a call to setup().
This series adds a new "setup" stage for modules initialization, which is executed once the setup() function completed. This stage is used by the cgroups module which requires some shutil functions at initialization time.