### PR TITLE
LinuxTarget: now used 'uname' instead of 'busybox uname'

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -525,7 +525,7 @@ class LinuxTarget(Target):
     @property
     @memoized
     def abi(self):
-        value = self.execute('{} uname -m'.format(self.busybox)).strip()
+        value = self.execute('uname -m').strip()
         for abi, architectures in ABI_MAP.iteritems():
             if value in architectures:
                 result = abi


### PR DESCRIPTION
To install busybox we need to know the ABI of the device to push the
correct binary but to know the ABI we need busybox.

Since uname is part of the POSIX standard and this issue only effects
the LinuxTarget (AndroidTarget gets this from build.prop) it is safe
to assume all LinuxTargets should have uname.