### PR TITLE
LinuxTarget: Allow determining target ABI without busybox

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -525,7 +525,14 @@ class LinuxTarget(Target):
     @property
     @memoized
     def abi(self):
-        value = self.execute('{} uname -m'.format(self.busybox)).strip()
+        if self.busybox:
+            value = self.execute('{} uname -m'.format(self.busybox)).strip()
+        else:
+            try:
+                value = self.execute('uname -m').strip()
+            except TargetError:
+                logging.error('Can\'t determine target ABI. ')
+                raise
         for abi, architectures in ABI_MAP.iteritems():
             if value in architectures:
                 result = abi


### PR DESCRIPTION
We need to know the target ABI in order to install busybox, therefore we
should attempt to find the ABI when busybox is not yet present. I'm not
aware of a clean way to do this if there's no `uname` command present,
so just raise an exception in that case.

Proposed solution to https://github.com/ARM-software/devlib/issues/43