### PR TITLE
Improve memoize decorator

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -33,6 +33,7 @@ from operator import itemgetter
 from itertools import groupby
 from functools import partial
 
+import wrapt
 
 # ABI --> architectures list
 ABI_MAP = {
@@ -536,17 +537,18 @@ def mask_to_list(mask):
 __memo_cache = {}
 
 
-def memoized(func):
+@wrapt.decorator
+def memoized(wrapped, instance, args, kwargs):
     """A decorator for memoizing functions and methods."""
-    func_id = repr(func)
+    func_id = repr(wrapped)
 
     def memoize_wrapper(*args, **kwargs):
         id_string = func_id + ','.join([str(id(a)) for a in  args])
         id_string += ','.join('{}={}'.format(k, v)
                               for k, v in kwargs.iteritems())
         if id_string not in __memo_cache:
-            __memo_cache[id_string] = func(*args, **kwargs)
+            __memo_cache[id_string] = wrapped(*args, **kwargs)
         return __memo_cache[id_string]
 
-    return memoize_wrapper
+    return memoize_wrapper(*args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ params = dict(
         'python-dateutil',  # converting between UTC and local time.
         'pexpect>=3.3',  # Send/recieve to/from device
         'pyserial',  # Serial port interface
+        'wrapt',  # Basic for construction of decorator functions
     ],
     extras_require={
         'daq': ['daqpower'],


### PR DESCRIPTION
Using the wrapt module we can improve the memoize decorator. In fact, it allows
to preserve the attributes of the memoized function, such as signature,
docstring, path to the file where the function is implemented, and so on.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>