### PR TITLE
cgroups: fix get_states() return value when passing integer state

### DIFF
--- a/devlib/module/cpuidle.py
+++ b/devlib/module/cpuidle.py
@@ -113,7 +113,7 @@ class Cpuidle(Module):
     def get_state(self, state, cpu=0):
         if isinstance(state, int):
             try:
-                self.get_states(cpu)[state].enable()
+                return self.get_states(cpu)[state]
             except IndexError:
                 raise ValueError('Cpuidle state {} does not exist'.format(state))
         else:  # assume string-like


### PR DESCRIPTION
When passing an idle state ID to get_states(), nothing is returned. Also, there
is a wrong call to enable() in the method.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>