### PR TITLE
cpufreq: always pass an integer to list_frequencies()

### DIFF
--- a/devlib/module/cpufreq.py
+++ b/devlib/module/cpufreq.py
@@ -217,7 +217,8 @@ class CpufreqModule(Module):
         """
         if isinstance(cpu, int):
             cpu = 'cpu{}'.format(cpu)
-        available_frequencies = self.list_frequencies(cpu)
+        # Assume cpu is always of the form "cpu<n>"
+        available_frequencies = self.list_frequencies(int(cpu[3:]))
         try:
             value = int(frequency)
             if exact and available_frequencies and value not in available_frequencies:
@@ -266,10 +267,11 @@ class CpufreqModule(Module):
         """
         if isinstance(cpu, int):
             cpu = 'cpu{}'.format(cpu)
+        # Assume cpu is always of the form "cpu<n>"
+        available_frequencies = self.list_frequencies(int(cpu[3:]))
         try:
             value = int(frequency)
             if exact:
-                available_frequencies = self.list_frequencies(cpu)
                 if available_frequencies and value not in available_frequencies:
                     raise TargetError('Can\'t set {} frequency to {}\nmust be in {}'.format(cpu,
                                                                                             value,
@@ -315,7 +317,8 @@ class CpufreqModule(Module):
         """
         if isinstance(cpu, int):
             cpu = 'cpu{}'.format(cpu)
-        available_frequencies = self.list_frequencies(cpu)
+        # Assume cpu is always of the form "cpu<n>"
+        available_frequencies = self.list_frequencies(int(cpu[3:]))
         try:
             value = int(frequency)
             if exact and available_frequencies and value not in available_frequencies:


### PR DESCRIPTION
Being list_frequencies() a memoized method, passing a string as input
argument works the first time, but subsequent calls fail apparently because the
memoized decorator always sees the same argument (probably same reference to the
string object).

This modifies every method that calls list_frequency() using a string to use an
integer instead.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>