### PR TITLE
Add support for CPUs isolation and tasks freezing

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -152,6 +152,17 @@ cgroups_tasks_move() {
 	done
 }
 
+cgroups_tasks_in() {
+	GRP=${1}
+	for TID in $($CAT $GRP/tasks); do
+		COMM=`$CAT /proc/$TID/comm 2>/dev/null`
+		[ "$COMM" != "" ] && CMDL=`$CAT /proc/$TID/cmdline 2>/dev/null`
+		[ "$COMM" != "" ] && echo "$TID,$COMM,$CMDL"
+	done
+	exit 0
+}
+
+
 ################################################################################
 # Main Function Dispatcher
 ################################################################################
@@ -180,6 +191,9 @@ cgroups_run_into)
     ;;
 cgroups_tasks_move)
 	cgroups_tasks_move $*
+	;;
+cgroups_tasks_in)
+	cgroups_tasks_in $*
 	;;
 ftrace_get_function_stats)
     ftrace_get_function_stats

--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -8,6 +8,7 @@ FIND=${FIND:-$BUSYBOX find}
 GREP=${GREP:-$BUSYBOX grep}
 SED=${SED:-$BUSYBOX sed}
 CAT=${CAT:-$BUSYBOX cat}
+AWK=${AWK:-$BUSYBOX awk}
 
 ################################################################################
 # CPUFrequency Utility Functions
@@ -134,20 +135,21 @@ cgroups_run_into() {
 cgroups_tasks_move() {
 	SRC_GRP=${1}
 	DST_GRP=${2}
-	GREP_EXCLUSE=${3:-''}
+	shift 2
+	FILTERS=$*
 
 	$CAT $SRC_GRP/tasks | while read TID; do
 	  echo $TID > $DST_GRP/cgroup.procs
 	done
 
-	[ "$GREP_EXCLUSE" = "" ] && exit 0
+	[ "x$FILTERS" = "x" ] && exit 0
 
-	PIDS=`ps | $GREP "$GREP_EXCLUSE" | awk '{print $2}'`
+	PIDS=`ps | $GREP $FILTERS | $AWK '{print $2}'`
 	PIDS=`echo $PIDS`
 	echo "PIDs to save: [$PIDS]"
 	for TID in $PIDS; do
-	  CMDLINE=`$CAT /proc/$TID/cmdline`
-	  echo "$TID : $CMDLINE"
+	  COMM =`$CAT /proc/$TID/comm`
+	  echo "$TID : $COMM"
 	  echo $TID > $SRC_GRP/cgroup.procs
 	done
 }

--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -7,6 +7,7 @@ BUSYBOX=${BUSYBOX:-__DEVLIB_BUSYBOX__}
 FIND=${FIND:-$BUSYBOX find}
 GREP=${GREP:-$BUSYBOX grep}
 SED=${SED:-$BUSYBOX sed}
+CAT=${CAT:-$BUSYBOX cat}
 
 ################################################################################
 # CPUFrequency Utility Functions
@@ -37,7 +38,7 @@ cpufreq_get_all_governors() {
 }
 
 cpufreq_trace_all_frequencies() {
-	FREQS=$(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq)
+	FREQS=$($CAT /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq)
 	CPU=0; for F in $FREQS; do
 		echo "cpu_frequency:        state=$F cpu_id=$CPU" > /sys/kernel/debug/tracing/trace_marker
 		CPU=$((CPU + 1))
@@ -51,7 +52,7 @@ cpufreq_trace_all_frequencies() {
 ftrace_get_function_stats() {
     for CPU in $(ls /sys/kernel/debug/tracing/trace_stat | sed 's/function//'); do
         REPLACE_STRING="s/  Function/\n  Function (CPU$CPU)/"
-        cat /sys/kernel/debug/tracing/trace_stat/function$CPU \
+        $CAT /sys/kernel/debug/tracing/trace_stat/function$CPU \
             | sed "$REPLACE_STRING"
     done
 }
@@ -135,7 +136,7 @@ cgroups_tasks_move() {
 	DST_GRP=${2}
 	GREP_EXCLUSE=${3:-''}
 
-	cat $SRC_GRP/tasks | while read TID; do
+	$CAT $SRC_GRP/tasks | while read TID; do
 	  echo $TID > $DST_GRP/cgroup.procs
 	done
 
@@ -145,7 +146,7 @@ cgroups_tasks_move() {
 	PIDS=`echo $PIDS`
 	echo "PIDs to save: [$PIDS]"
 	for TID in $PIDS; do
-	  CMDLINE=`cat /proc/$TID/cmdline`
+	  CMDLINE=`$CAT /proc/$TID/cmdline`
 	  echo "$TID : $CMDLINE"
 	  echo $TID > $SRC_GRP/cgroup.procs
 	done

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -117,19 +117,16 @@ class Controller(object):
             cgroups.append(cg)
         return cgroups
 
-    def move_tasks(self, source, dest):
+    def move_tasks(self, source, dest, exclude=[]):
         try:
             srcg = self._cgroups[source]
             dstg = self._cgroups[dest]
-            command = 'for task in $(cat {}); do echo $task>{}; done'
-            self.target.execute(command.format(srcg.tasks_file, dstg.tasks_file),
-                                # this will always fail as some of the tasks
-                                # are kthreads that cannot be migrated, but we
-                                # don't care about those, so don't check exit
-                                # code.
-                                check_exit_code=False, as_root=True)
         except KeyError as e:
             raise ValueError('Unkown group: {}'.format(e))
+        output = self.target._execute_util(
+                    'cgroups_tasks_move {} {} \'{}\''.format(
+                    srcg.directory, dstg.directory, exclude),
+                    as_root=True)
 
     def move_all_tasks_to(self, dest):
         for cgroup in self._cgroups:

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -136,6 +136,28 @@ class Controller(object):
             if cgroup != dest:
                 self.move_tasks(cgroup, dest)
 
+    def tasks(self, cgroup):
+        try:
+            cg = self._cgroups[cgroup]
+        except KeyError as e:
+            raise ValueError('Unkown group: {}'.format(e))
+        output = self.target._execute_util(
+                    'cgroups_tasks_in {}'.format(cg.directory),
+                    as_root=True)
+        entries = output.splitlines()
+        tasks = {}
+        for task in entries:
+            tid = task.split(',')[0]
+            try:
+                tname = task.split(',')[1]
+            except: continue
+            try:
+                tcmdline = task.split(',')[2]
+            except:
+                tcmdline = ''
+            tasks[int(tid)] = (tname, tcmdline)
+        return tasks
+
 class CGroup(object):
 
     def __init__(self, controller, name, create=True):

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -158,6 +158,23 @@ class Controller(object):
             tasks[int(tid)] = (tname, tcmdline)
         return tasks
 
+    def tasks_count(self, cgroup):
+        try:
+            cg = self._cgroups[cgroup]
+        except KeyError as e:
+            raise ValueError('Unkown group: {}'.format(e))
+        output = self.target.execute(
+                    '{} wc -l {}/tasks'.format(
+                    self.target.busybox, cg.directory),
+                    as_root=True)
+        return int(output.split()[0])
+
+    def tasks_per_group(self):
+        tasks = {}
+        for cg in self.list_all():
+            tasks[cg] = self.tasks_count(cg)
+        return tasks
+
 class CGroup(object):
 
     def __init__(self, controller, name, create=True):


### PR DESCRIPTION
This series adds some fixes for the CGroup module and a couple of new functionalities:
- isolation: which allows to isolate a specified list of CPUs by moving all tasks in the remaining CPUs
- freezer: which allows to freeze all the tasks of the target

Both functions accept a list of tasks to exclude. Excluded tasks are keept in the root CGroups thus:
- they can run on isolated CPUs
- they are not frozen

@mdigiorgio can be interested in reviewing/testing these functions, since they should be useful for its energy-model building flow ;-)
