### PR TITLE
android: don't try to disconnect devices which aren't connected

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -291,7 +291,7 @@ def adb_disconnect(device):
     _check_env()
     if not device:
         return
-    if ":" in device:
+    if ":" in device and device in adb_list_devices():
         command = "adb disconnect " + device
         logger.debug(command)
         retval = subprocess.call(command, stdout=open(os.devnull, 'wb'), shell=True)


### PR DESCRIPTION
Just a tiny problem here, but it is preventing me from using Juno over tcpip :)

If you try to disconnect a device and there are none, certain versions
of adb return 1, which leads to a TargetError and stops everything in
its tracks.

Try to mitigate this by checking if the device we want to disconnect is
connected before we make the disconnect call.
