### PR TITLE
cpufreq: Improve error when setting all CPUs to unsupported governor

### DIFF
--- a/devlib/module/cpufreq.py
+++ b/devlib/module/cpufreq.py
@@ -375,9 +375,18 @@ class CpufreqModule(Module):
         """
         Set the specified governor for all the (online) CPUs
         """
-        return self.target._execute_util(
+        try:
+            return self.target._execute_util(
                 'cpufreq_set_all_governors {}'.format(governor),
                 as_root=True)
+        except TargetError as e:
+            if "echo: I/O error" in str(e):
+                cpus_unsupported = [c for c in self.target.list_online_cpus()
+                                    if governor not in self.list_governors(c)]
+                raise TargetError("Governor {} unsupported for CPUs {}".format(
+                    governor, cpus_unsupported))
+            else:
+                raise
 
     def get_all_governors(self):
         """


### PR DESCRIPTION
Currently when using set_all_governors to try to set an unsupported
governor, the error is a somewhat cryptic "sh: echo: I/O error". Add a
check that diagnoses this error.

In order to avoid slowing down the "good" path, the check for
unsupported governors is only done if the failure has already occured.