### PR TITLE
shutils.in: rename manually injected cpu_frequency trace event

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -41,7 +41,7 @@ cpufreq_get_all_governors() {
 cpufreq_trace_all_frequencies() {
 	FREQS=$($CAT /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq)
 	CPU=0; for F in $FREQS; do
-		echo "cpu_frequency:        state=$F cpu_id=$CPU" > /sys/kernel/debug/tracing/trace_marker
+		echo "cpu_frequency_devlib:        state=$F cpu_id=$CPU" > /sys/kernel/debug/tracing/trace_marker
 		CPU=$((CPU + 1))
 	done
 }


### PR DESCRIPTION
The injection of a fake cpu_frequency event in the trace may end up getting
interleaved with trace events generated by the cpufreq governor, for example:

  sh         ... cpu_frequency: state=120000 cpu_id=0
  kschedfreq ... cpu_frequency: state=120000 cpu_id=0
  kschedfreq ... cpu_frequency: state=120000 cpu_id=1
  kschedfreq ... cpu_frequency: state=120000 cpu_id=2
  kschedfreq ... cpu_frequency: state=120000 cpu_id=3
  sh         ... cpu_frequency: state=120000 cpu_id=1
  sh         ... cpu_frequency: state=120000 cpu_id=2
  sh         ... cpu_frequency: state=120000 cpu_id=3

Such a trace may confuse trace parsers during postprocessing and lead to wrong
or no results.

This patch renames the events injected by devlib so that they can be easily
recognized and then used by the trace parser in the best way.

Signed-off-by: Michele Di Giorgio michele.digiorgio@arm.com
