### PR TITLE
ftrace: Poke all CPUs before collecting trace

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -47,6 +47,18 @@ cpufreq_trace_all_frequencies() {
 }
 
 ################################################################################
+# CPUIdle Utility Functions
+################################################################################
+
+cpuidle_wake_all_cpus() {
+	CPU_PATHS=/sys/devices/system/cpu/cpu[0-9]*
+	MASK=0x1; for F in $CPU_PATHS; do
+		$BUSYBOX taskset $MASK true
+		MASK=$($BUSYBOX printf '0x%x' $((MASK * 2)))
+	done
+}
+
+################################################################################
 # FTrace Utility Functions
 ################################################################################
 
@@ -184,6 +196,9 @@ cpufreq_get_all_governors)
     ;;
 cpufreq_trace_all_frequencies)
     cpufreq_trace_all_frequencies $*
+    ;;
+cpuidle_wake_all_cpus)
+    cpuidle_wake_all_cpus $*
     ;;
 cgroups_get_attributes)
 	cgroups_get_attributes $*

--- a/devlib/module/cpuidle.py
+++ b/devlib/module/cpuidle.py
@@ -152,3 +152,9 @@ class Cpuidle(Module):
         for state in self.get_states(cpu):
             state.disable()
 
+    def perturb_cpus(self):
+        """
+        Momentarily wake each CPU. Ensures cpu_idle events in trace file.
+        """
+        output = self.target._execute_util('cpuidle_wake_all_cpus')
+        print(output)

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -170,6 +170,9 @@ class FtraceCollector(TraceCollector):
         if 'cpufreq' in self.target.modules:
             self.logger.debug('Trace CPUFreq frequencies')
             self.target.cpufreq.trace_frequencies()
+        if 'cpuidle' in self.target.modules:
+            self.logger.debug('Trace CPUIdle states')
+            self.target.cpuidle.perturb_cpus()
         # Enable kernel function profiling
         if self.functions:
             self.target.execute('echo nop > {}'.format(self.current_tracer_file),


### PR DESCRIPTION
On some systems CPUs sometimes remain idle for several seconds. If a
trace capture begins during one of these long idle periods, that CPU's
idle state is unknown (in practice it is probably in its deepest
available state from cpuidle's perspective but that can't be known for
sure).

The solution to the equivalent problem for cpufreq is to read the
current frequencies from sysfs and inject artificial cpu_frequency
events using trace_marker (see cpu_freq_trace_all_frequencies in
bin/scripts/shutils.in). However we can't read the current idle state
from sysfs.

Instead, wake up each CPU by executing the "true" command on it via
taskset.