### PR TITLE
android: Fixed issue using single quoted command with adb_shell

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -334,14 +334,15 @@ def adb_shell(device, command, timeout=None, check_exit_code=False,
     _check_env()
     if as_root:
         command = 'echo \'{}\' | su'.format(escape_single_quotes(command))
-    device_string = ' -s {}'.format(device) if device else ''
+    device_part = ['-s', device] if device else []
+    device_string = ' {} {}'.format(*device_part) if device_part else ''
     full_command = 'adb{} shell "{}"'.format(device_string,
                                              escape_double_quotes(command))
     logger.debug(full_command)
     if check_exit_code:
-        actual_command = "adb{} shell '({}); echo \"\n$?\"'".format(device_string,
-                                                                    escape_single_quotes(command))
-        raw_output, error = check_output(actual_command, timeout, shell=True)
+        adb_shell_command = '({}); echo \"\n$?\"'.format(command)
+        actual_command = ['adb'] + device_part + ['shell', adb_shell_command]
+        raw_output, error = check_output(actual_command, timeout, shell=False)
         if raw_output:
             try:
                 output, exit_code, _ = raw_output.rsplit(newline_separator, 2)


### PR DESCRIPTION
When using 'check_exit_code' and 'as_root' options for adb_shell with
a command containing single quotes, the provided command was escaped
twice. The second escaping has been avoided and some unit tests added
to check functionality.