### PR TITLE
cgroups: ensure CGroups are mounted RW

### DIFF
--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -326,6 +326,11 @@ class CgroupsModule(Module):
             self.logger.debug('cgroup_root already mounted at %s',
                     self.cgroup_root)
 
+        # Ensure CGroups is mounted RW
+        self.target.execute('mount -o remount,rw {}'\
+                            .format(self.cgroup_root),
+                            as_root=True)
+
         # Load list of available controllers
         controllers = []
         subsys = self.list_subsystems()


### PR DESCRIPTION
Some systems mount CGroups RO, thus we need to ensure we remount that
FS as root otherwise we cannot create new groups.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>