### PR TITLE
target: Note return value in Target::invoke docstring

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -288,6 +288,7 @@ class Target(object):
                   a ``TimeoutError`` exception will be raised. Set to ``None`` if the
                   invocation should not timeout.
 
+        :returns: output of command.
         """
         command = binary
         if args:


### PR DESCRIPTION
I can't get sphinx to build the docs to check if this is the right syntax.. it feels too trivial to spend any more time on so feel free to just close this if it looks wrong.