### PR TITLE
android: Fix whitespace in wildcard match for ADB pull

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -210,7 +210,7 @@ class AdbConnection(object):
             command = 'shell {} {}'.format(self.ls_command, source)
             output = adb_command(self.device, command, timeout=timeout)
             for line in output.splitlines():
-                command = "pull '{}' '{}'".format(line, dest)
+                command = "pull '{}' '{}'".format(line.strip(), dest)
                 adb_command(self.device, command, timeout=timeout)
             return
         command = "pull '{}' '{}'".format(source, dest)


### PR DESCRIPTION
I have observed that when there are multiple matches for the wildcard, `line` has a space at the end. That means the `pull` command doesn't work.