### PR TITLE
devlib: strip space for adb pull source dir

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -210,6 +210,7 @@ class AdbConnection(object):
             command = 'shell {} {}'.format(self.ls_command, source)
             output = adb_command(self.device, command, timeout=timeout)
             for line in output.splitlines():
+                line = line.strip()
                 command = "pull '{}' '{}'".format(line, dest)
                 adb_command(self.device, command, timeout=timeout)
             return


### PR DESCRIPTION
There may be space at the end of the string line.
This will cause adb pull failed.