### PR TITLE
Fixes for cgroups

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -160,7 +160,7 @@ cgroups_tasks_move() {
 	PIDS=`echo $PIDS`
 	echo "PIDs to save: [$PIDS]"
 	for TID in $PIDS; do
-	  COMM =`$CAT /proc/$TID/comm`
+	  COMM=`$CAT /proc/$TID/comm`
 	  echo "$TID : $COMM"
 	  echo $TID > $SRC_GRP/cgroup.procs
 	done

--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -9,6 +9,7 @@ GREP=${GREP:-$BUSYBOX grep}
 SED=${SED:-$BUSYBOX sed}
 CAT=${CAT:-$BUSYBOX cat}
 AWK=${AWK:-$BUSYBOX awk}
+PS=${PS:-$BUSYBOX ps}
 
 ################################################################################
 # CPUFrequency Utility Functions
@@ -156,7 +157,7 @@ cgroups_tasks_move() {
 
 	[ "x$FILTERS" = "x" ] && exit 0
 
-	PIDS=`ps | $GREP $FILTERS | $AWK '{print $2}'`
+	PIDS=`$PS -o comm,pid | $GREP $FILTERS | $AWK '{print $2}'`
 	PIDS=`echo $PIDS`
 	echo "PIDs to save: [$PIDS]"
 	for TID in $PIDS; do

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -300,7 +300,6 @@ class CgroupsModule(Module):
 
     name = 'cgroups'
     stage = 'setup'
-    cgroup_root = '/sys/fs/cgroup'
 
     @staticmethod
     def probe(target):
@@ -314,22 +313,6 @@ class CgroupsModule(Module):
         super(CgroupsModule, self).__init__(target)
 
         self.logger = logging.getLogger('CGroups')
-
-        # Initialize controllers mount point
-        mounted = self.target.list_file_systems()
-        if self.cgroup_root not in [e.mount_point for e in mounted]:
-            self.target.execute('mount -t tmpfs {} {}'\
-                    .format('cgroup_root',
-                            self.cgroup_root),
-                            as_root=True)
-        else:
-            self.logger.debug('cgroup_root already mounted at %s',
-                    self.cgroup_root)
-
-        # Ensure CGroups is mounted RW
-        self.target.execute('mount -o remount,rw {}'\
-                            .format(self.cgroup_root),
-                            as_root=True)
 
         # Load list of available controllers
         controllers = []
@@ -346,7 +329,9 @@ class CgroupsModule(Module):
             if not controller.probe(self.target):
                 continue
             try:
-                controller.mount(self.target, self.cgroup_root)
+                cgroup_root = target.path.join(target.working_directory,
+                                               'cgroups')
+                controller.mount(self.target, cgroup_root)
             except TargetError:
                 message = 'cgroups {} controller is not supported by the target'
                 raise TargetError(message.format(controller.kind))

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -155,7 +155,7 @@ class Controller(object):
         # Build list of tasks to exclude
         grep_filters = ''
         for comm in exclude:
-            grep_filters += '-e "{}" '.format(comm)
+            grep_filters += '-e {} '.format(comm)
         logging.debug('   using grep filter: %s', grep_filters)
         if grep_filters != '':
             logging.debug('   excluding tasks which name matches:')

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -448,6 +448,8 @@ class CgroupsModule(Module):
 
         # Create Freezer CGroup
         freezer = self.controller('freezer')
+        if freezer is None:
+            raise RuntimeError('freezer cgroup controller not present')
         freezer_cg = freezer.cgroup('/DEVLIB_FREEZER')
         thawed_cg = freezer.cgroup('/')
 


### PR DESCRIPTION
An assortment of fixes for cgroups.py and shutils. CC @derkling 

Not fixed: "CgroupsModule::freeze(exclude=['sh'])" will also not freeze any process with "sh" in the comm so `sshd` etc will not be frozen.