### PR TITLE
shutils/cgroups: Don't fail when racing with process exit

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -163,7 +163,7 @@ cgroups_tasks_move() {
 	for TID in $PIDS; do
 	  COMM=`$CAT /proc/$TID/comm`
 	  echo "$TID : $COMM"
-	  echo $TID > $SRC_GRP/cgroup.procs
+	  echo $TID > $SRC_GRP/cgroup.procs || true
 	done
 }
 


### PR DESCRIPTION
If a process is added to $PIDS but then exits before the
cgroups_task_move invokation finishes, then echoing its PID to
cgroups.procs results in an I/O error. If that process is the last in
$PIDS, then that failing echo command is the last of the function, so
the script exits with an error and devlib raises an exception.

Add `|| true` to avoid this problem.

---

CC @derkling 