### PR TITLE
Cgroups multi controller

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -102,7 +102,7 @@ cgroups_get_attributes() {
 cgroups_run_into() {
 
 	# Control groups mount point
-	CGMOUNT=${CGMOUNT:-/sys/fs/cgroup/devlib_*}
+	CGMOUNT=${CGMOUNT:-/sys/fs/cgroup}
 	# The control group we want to run into
 	CGP=${1}
 	shift 1

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -318,17 +318,17 @@ class CgroupsModule(Module):
         self.cgroup_root = target.path.join(
             target.working_directory, 'cgroups')
 
-        # Load list of available controllers
-        controllers = []
+        # Get the list of the available controllers
         subsys = self.list_subsystems()
-        for (n, h, c, e) in subsys:
-            controllers.append(n)
-        self.logger.debug('Available controllers: %s', controllers)
+        if len(subsys) == 0:
+            self.logger.warning('No CGroups controller available')
+            return
 
         # Initialize controllers
+        self.logger.info('Available controllers:')
         self.controllers = {}
-        for idx in controllers:
-            controller = Controller(idx)
+        for ss in subsys:
+            controller = Controller(ss.name)
             self.logger.debug('Init %s controller...', controller.kind)
             if not controller.probe(self.target):
                 continue
@@ -338,7 +338,7 @@ class CgroupsModule(Module):
                 message = 'cgroups {} controller is not supported by the target'
                 raise TargetError(message.format(controller.kind))
             self.logger.debug('Controller %s enabled', controller.kind)
-            self.controllers[idx] = controller
+            self.controllers[ss.name] = controller
 
     def list_subsystems(self):
         subsystems = []


### PR DESCRIPTION
Here is a series of modifications which introduce the support for multi-controller hierarchies to the CGroup module. This support is requires whenever we want to use CGroups in a system which has already some controllers mounted together in a single hierarchy, which is a quite common case.

This series fixes also some errors introduced in previous patches regrading the execution of a workload under a specified cgroup.