### PR TITLE
LocalConnection: Add ignored `platform` param to __init__ method

### DIFF
--- a/devlib/host.py
+++ b/devlib/host.py
@@ -29,8 +29,8 @@ class LocalConnection(object):
 
     name = 'local'
 
-    def __init__(self, keep_password=True, unrooted=False, password=None,
-                 timeout=None):
+    def __init__(self, platform=None, keep_password=True, unrooted=False,
+                 password=None, timeout=None):
         self.logger = logging.getLogger('local_connection')
         self.keep_password = keep_password
         self.unrooted = unrooted


### PR DESCRIPTION
This parameter is used by the other connection classes and as of
21f40035d785 ("gem5: Small tweaks in target to allow gem5 simulations") is
passed by to the connection class constructor via expansion of
Target.connection_settings (see Target.get_connection)

---

Relevant code [here](https://github.com/ARM-software/devlib/commit/21f40035d785950c439a77303b162940978e6fac#diff-ace949208afde1948ca24e3746a5e425R170) and  [here](https://github.com/ARM-software/devlib/blob/21f40035d785950c439a77303b162940978e6fac/devlib/target.py#L215)