### PR TITLE
target: better parse kernel version numbers

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -26,6 +26,9 @@ ANDROID_SCREEN_RESOLUTION_REGEX = re.compile(r'mUnrestrictedScreen=\(\d+,\d+\)'
                                              r'\s+(?P<width>\d+)x(?P<height>\d+)')
 DEFAULT_SHELL_PROMPT = re.compile(r'^.*(shell|root)@.*:/\S* [#$] ',
                                   re.MULTILINE)
+KVERSION_REGEX =re.compile(
+    r'(?P<version>\d+)(\.(?P<major>\d+)(\.(?P<minor>\d+)(-(rc)?(?P<rc>\d+))?)?)?(.*-g(?P<sha1>[0-9a-fA-F]{7,}))?'
+)
 
 
 class Target(object):
@@ -1198,6 +1201,19 @@ class KernelVersion(object):
         else:
             self.release = version_string
             self.version = ''
+
+        self.version_number = None
+        self.major = None
+        self.minor = None
+        self.sha1 = None
+        self.rc = None
+        match = KVERSION_REGEX.match(version_string)
+        if match:
+            self.version_number = match.group('version')
+            self.major = match.group('major')
+            self.minor = match.group('minor')
+            self.sha1 = match.group('sha1')
+            self.rc = match.group('rc')
 
     def __str__(self):
         return '{} {}'.format(self.release, self.version)


### PR DESCRIPTION
This adds a regexp to better parse all the kernel version numbers as well
as additional (optional) fields like SHA1 and RC.

The regexp has been made generic enough to match these examples:

4.9.0-rc6-00202-g3a60597
4.9.0-rc6-00202
4.9.0-rc6-00202-g3a60597 #321 SMP PREEMPT Mon Feb 13 12:30:59 GMT 2017 aarch64 GNU/Linux
3.18.31-g226dafe #1 SMP PREEMPT Wed Feb 15 16:34:14 GMT 2017
4.4.0-59-generic #80~14.04.1-Ubuntu SMP Fri Jan 6 18:02:02 UTC 2017
3.11.0-26-generic #45~precise1-Ubuntu SMP Tue Jul 15 04:02:35 UTC 2014
3.13.0-107-generic #154-Ubuntu SMP Tue Dec 20 09:57:27 UTC 2016
3.13.0-generic #154-Ubuntu SMP Tue Dec 20 09:57:27 UTC 2016
4.8.0 #1 SMP Fri Jan 6 18:06:24 GMT 2017

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>