### PR TITLE
android: add support for forced adb root

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1040,9 +1040,9 @@ class AndroidTarget(Target):
     def adb_reboot_bootloader(self, timeout=30):
         adb_command(self.adb_name, 'reboot-bootloader', timeout)
 
-    def adb_root(self, enable=True):
+    def adb_root(self, enable=True, force=False):
         if enable:
-            if self._connected_as_root:
+            if self._connected_as_root and not force:
                 return
             adb_command(self.adb_name, 'root', timeout=30)
             self._connected_as_root = True


### PR DESCRIPTION
When rebooting a platform the internal connection state becomes
different from _connected_as_root, which was set before reboot.

Add the possibility to force adb root if you've rebooted or know
to have done something that would result in the platform having
a different connection state than the one of _connected_as_root.

Signed-off-by: Ionela Voinescu <ionela.voinescu@arm.com>