### PR TITLE
android: Improve error when _setup_ls fails

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -177,7 +177,12 @@ class AdbConnection(object):
     # versions of the ls tool in Android pre-v7.
     def _setup_ls(self):
         command = "shell '(ls -1); echo \"\n$?\"'"
-        output = adb_command(self.device, command, timeout=self.timeout)
+        try:
+            output = adb_command(self.device, command, timeout=self.timeout)
+        except subprocess.CalledProcessError as e:
+            raise HostError(
+                'Failed to set up ls command on Android device. Output:\n'
+                + e.output)
         lines = output.splitlines()
         retval = lines[-1].strip()
         if int(retval) == 0:


### PR DESCRIPTION
If the ADB command fails (e.g. if you provide the wrong device ID), adb_command
raises a CalledProcessError. CalledProcessError doesn't print the output of the
failed command, so you get a useless error message.

This is relevent here in particular as _setup_ls is the first thing to run an
ADB command if a non-IP device ID is provided.

Catch the CalledProcessError and instead raise a HostError with the command
output in the exception message.