### PR TITLE
energy_probe: Check if caimain was broken and raise an error

### DIFF
--- a/devlib/instrument/energy_probe.py
+++ b/devlib/instrument/energy_probe.py
@@ -82,6 +82,13 @@ class EnergyProbeInstrument(Instrument):
                                         shell=True)
 
     def stop(self):
+        self.process.poll()
+        if self.process.returncode is not None:
+            stdout, stderr = self.process.communicate()
+            raise HostError(
+                'Energy Probe: Caiman exited unexpectedly with exit code {}.\n'
+                'stdout:\n{}\nstderr:\n{}'.format(self.process.returncode,
+                                                  stdout, stderr))
         os.killpg(self.process.pid, signal.SIGTERM)
 
     def get_data(self, outfile):  # pylint: disable=R0914


### PR DESCRIPTION
This means when caiman is broken you can see the error message, instead of just
finding out later that there is no data.

We still don't detect caiman being broken until we call stop(), but it's still
an improvement.