### PR TITLE
gem5: Set the kernel log level to 1

### DIFF
--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -374,6 +374,11 @@ class Gem5Connection(TelnetConnection):
         # Wait for boot
         self._wait_for_boot()
 
+        # Before we do anything else, we need to make sure that the
+        # terminal is as quiet as possible! Therefore, we set the
+        # lowest log level.
+        self._gem5_shell('su -c "dmesg -n 1" root')
+
         # Mount the virtIO to transfer files in/out gem5 system
         self._mount_virtio()
 


### PR DESCRIPTION
When running with gem5, we use the same virtual terminal as is used
for the kernel log. This can cause issues when the kernel prints, as
we might be trying to parse the output from a command. This can cause
runs to crash. We therefore set the kernel log level to 1 by default,
which should supress all log messages aside from ones such as kernel
panics. This setting is changed as the first thing once we have
established a reliable connection with the simulated device.