### PR TITLE
cpufreq: Expose error when writing invalid governor tunable

### DIFF
--- a/devlib/module/cpufreq.py
+++ b/devlib/module/cpufreq.py
@@ -152,10 +152,14 @@ class CpufreqModule(Module):
         valid_tunables = self.list_governor_tunables(cpu)
         for tunable, value in kwargs.iteritems():
             if tunable in valid_tunables:
+                path = '/sys/devices/system/cpu/{}/cpufreq/{}/{}'.format(cpu, governor, tunable)
                 try:
-                    path = '/sys/devices/system/cpu/{}/cpufreq/{}/{}'.format(cpu, governor, tunable)
                     self.target.write_value(path, value)
-                except TargetError:  # May be an older kernel
+                except TargetError:
+                    if self.target.file_exists(path):
+                        # File exists but we did something wrong
+                        raise
+                    # Expected file doesn't exist, try older sysfs layout.
                     path = '/sys/devices/system/cpu/cpufreq/{}/{}'.format(governor, tunable)
                     self.target.write_value(path, value)
             else:


### PR DESCRIPTION
If we get an TargetError when trying to set a governor tunable we currently fall
back to an older sysfs layout under the assumption that the file we tried to
write doesn't exist. However it may be that the file exists, but we tried to
write an invalid value (or something else went wrong). In this case we fall back
to the old file location, fail, and produce a nonsense error about the old path
not existing.

Instead, when we get a TargetError, check if the file exists, and fall back to
the old location only if it does not.