### PR TITLE
AndroidTarget: Fix `ps` when NAME column contains spaces

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -929,7 +929,7 @@ class AndroidTarget(Target):
         lines.next()  # header
         result = []
         for line in lines:
-            parts = line.split()
+            parts = line.split(None, 8)
             if parts:
                 result.append(PsEntry(*(parts[0:1] + map(int, parts[1:5]) + parts[5:])))
         if not kwargs:


### PR DESCRIPTION
Targets have been observed where `ps` output contains entries with NAME columns
of the form "[foo bar]". This means the `parts` list is too long and the PsEntry
call reports too many arguments. Since NAME is the rightmost column, just fix
the number of entries we recognise to 8.