### PR TITLE
Target: Stopped `kick_off` raising an error if command didn't timeout

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -882,8 +882,6 @@ class AndroidTarget(Target):
             output = self.execute(command, timeout=1, as_root=as_root)
         except TimeoutError:
             pass
-        else:
-            raise ValueError('Background command exited before timeout; got "{}"'.format(output))
 
     def __setup_list_directory(self):
         # In at least Linaro Android 16.09 (which was their first Android 7 release) and maybe


### PR DESCRIPTION
On some devices backgrounding a task results in the command returning
immediately with no error. This was falsely interpreted as the command failing
to run, therefore the additional check has been removed.