### PR TITLE
shutils: Speed up cpuidle_wake_all_cpus

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -54,7 +54,7 @@ cpufreq_trace_all_frequencies() {
 cpuidle_wake_all_cpus() {
 	CPU_PATHS=/sys/devices/system/cpu/cpu[0-9]*
 	MASK=0x1; for F in $CPU_PATHS; do
-		$BUSYBOX taskset $MASK true
+		$BUSYBOX taskset $MASK true &
 		MASK=$($BUSYBOX printf '0x%x' $((MASK * 2)))
 	done
 }


### PR DESCRIPTION
This can currently take several hundred milliseconds on slow targets with many
CPUs. To speed it up, use '&' to spawn the perturbations in paralell.