### PR TITLE
Target: Add read permissions to tmp files before pulling

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -961,6 +961,7 @@ class AndroidTarget(Target):
             device_tempfile = self.path.join(self._file_transfer_cache, source.lstrip(self.path.sep))
             self.execute("mkdir -p '{}'".format(self.path.dirname(device_tempfile)))
             self.execute("cp '{}' '{}'".format(source, device_tempfile), as_root=True)
+            self.execute("chmod 0644 '{}'".format(device_tempfile), as_root=True)
             self.conn.pull(device_tempfile, dest, timeout=timeout)
 
     # Android-specific


### PR DESCRIPTION
Previously trying to pull a file from an android target would fail if the file
was owned by root, this commit adds read permissions to the file before
attempting to pull.