### PR TITLE
instrument: Fix get_channels method

### DIFF
--- a/devlib/instrument/__init__.py
+++ b/devlib/instrument/__init__.py
@@ -179,7 +179,7 @@ class Instrument(object):
     def get_channels(self, measure):
         if hasattr(measure, 'name'):
             measure = measure.name
-        return [c for c in self.channels if c.measure.name == measure]
+        return [c for c in self.list_channels() if c.kind == measure]
 
     def add_channel(self, site, measure, name=None, **attrs):
         if name is None:


### PR DESCRIPTION
- `Instrument.channels` is a dictionary, we want the values not the
   keys; this is provded by `list_channels`.

- `InstrumentChannel` objects do not have a `measure` attribute. Use
  `kind` instead.