### PR TITLE
Add sample_rate_hz attribute to CONTINUOUS instruments

### DIFF
--- a/devlib/instrument/__init__.py
+++ b/devlib/instrument/__init__.py
@@ -170,6 +170,7 @@ class Instrument(object):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.channels = collections.OrderedDict()
         self.active_channels = []
+        self.sample_rate_hz = None
 
     # channel management
 

--- a/devlib/instrument/daq.py
+++ b/devlib/instrument/daq.py
@@ -27,7 +27,7 @@ class DaqInstrument(Instrument):
                  device_id='Dev1',
                  v_range=2.5,
                  dv_range=0.2,
-                 sampling_rate=10000,
+                 sample_rate_hz=10000,
                  channel_map=(0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23),
                  ):
         # pylint: disable=no-member
@@ -51,11 +51,11 @@ class DaqInstrument(Instrument):
         self.device_config = DeviceConfiguration(device_id=device_id,
                                                  v_range=v_range,
                                                  dv_range=dv_range,
-                                                 sampling_rate=sampling_rate,
+                                                 sampling_rate=sample_rate_hz,
                                                  resistor_values=resistor_values,
                                                  channel_map=channel_map,
                                                  labels=labels)
-        self.sample_rate_hz = sampling_rate
+        self.sample_rate_hz = sample_rate_hz
 
         for label in labels:
             for kind in ['power', 'voltage']:

--- a/devlib/instrument/daq.py
+++ b/devlib/instrument/daq.py
@@ -55,6 +55,7 @@ class DaqInstrument(Instrument):
                                                  resistor_values=resistor_values,
                                                  channel_map=channel_map,
                                                  labels=labels)
+        self.sample_rate_hz = sampling_rate
 
         for label in labels:
             for kind in ['power', 'voltage']:

--- a/devlib/instrument/energy_probe.py
+++ b/devlib/instrument/energy_probe.py
@@ -51,6 +51,7 @@ class EnergyProbeInstrument(Instrument):
         self.command = None
         self.raw_output_directory = None
         self.process = None
+        self.sample_rate_hz = 10000 # Determined empirically
 
         for label in self.labels:
             for kind in self.attributes:

--- a/devlib/platform/arm.py
+++ b/devlib/platform/arm.py
@@ -236,6 +236,7 @@ class JunoEnergyInstrument(Instrument):
         for chan in self._channels:
             self.channels[chan.name] = chan
         self.on_target_file = self.target.tempfile('energy', '.csv')
+        self.sample_rate_hz = 10 # DEFAULT_PERIOD is 100[ms] in readenergy.c
         self.command = '{} -o {}'.format(self.binary, self.on_target_file)
         self.command2 = '{}'.format(self.binary)
 

--- a/doc/instrumentation.rst
+++ b/doc/instrumentation.rst
@@ -146,6 +146,12 @@ Instrument
    .. note:: This method is only implemented by :class:`Instrument`\ s that
              support ``CONTINUOUS`` measurment.
 
+.. attribute:: Instrument.sample_rate_hz
+
+   Sample rate of the instrument in Hz. Assumed to be the same for all channels.
+
+   .. note:: This attribute is only provided by :class:`Instrument`\ s that
+             support ``CONTINUOUS`` measurment.
 
 Instrument Channel
 ~~~~~~~~~~~~~~~~~~

--- a/doc/instrumentation.rst
+++ b/doc/instrumentation.rst
@@ -28,7 +28,7 @@ Android target.
     # a no-op, but is included here for completeness.
     In [4]: i.setup()
 
-    # Find out what the instrument is capable collecting from the 
+    # Find out what the instrument is capable collecting from the
     # target.
     In [5]: i.list_channels()
     Out[5]:
@@ -40,7 +40,7 @@ Android target.
     In [6]: i.reset(sites=['exynos-therm'])
 
     # HWMON instrument supports INSTANTANEOUS collection, so invoking
-    # take_measurement() will return a list of measurements take from 
+    # take_measurement() will return a list of measurements take from
     # each of the channels configured during reset()
     In [7]: i.take_measurement()
     Out[7]: [exynos-therm_temperature: 36.0 degrees]
@@ -68,7 +68,7 @@ Instrument
                 period of time via ``start()``, ``stop()``, and
                 ``get_data()`` methods.
 
-   .. note:: It's possible for one instrument to support more than a single 
+   .. note:: It's possible for one instrument to support more than a single
              mode.
 
 .. attribute:: Instrument.active_channels
@@ -133,9 +133,9 @@ Instrument
 
 .. method:: Instrument.get_data(outfile)
 
-   Write collected data into ``outfile``. Must be called after :func:`stop()`. 
+   Write collected data into ``outfile``. Must be called after :func:`stop()`.
    Data will be written in CSV format with a column for each channel and a row
-   for each sample. Column heading will be channel, labels in the form 
+   for each sample. Column heading will be channel, labels in the form
    ``<site>_<kind>`` (see :class:`InstrumentChannel`). The order of the coluns
    will be the same as the order of channels in ``Instrument.active_channels``.
 


### PR DESCRIPTION
Don't have a DAQ so couldn't test that. Also couldn't get the Juno readenergy.c instrument working on my board. Decided that this can't really break anything, though.