### PR TITLE
target: add dry run for command execution

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -145,6 +145,10 @@ class Target(object):
         else:
             return None
 
+    @property
+    def dryrun(self):
+        return self._dryrun
+
     def __init__(self,
                  connection_settings=None,
                  platform=None,
@@ -186,6 +190,8 @@ class Target(object):
         self._cache = {}
         self._connections = {}
         self.busybox = None
+        self._dryrun_enabled = False
+        self._dryrun = []
 
         if load_default_modules:
             module_lists = [self.default_modules]
@@ -311,8 +317,20 @@ class Target(object):
 
     # execution
 
+    def start_dryrun(self):
+        if not self._dryrun_enabled:
+            self._dryrun_enabled = True
+            self._dryrun = []
+
+    def stop_dryrun(self):
+        if self._dryrun_enabled:
+            self._dryrun_enabled = False
+
     def execute(self, command, timeout=None, check_exit_code=True, as_root=False):
-        return self.conn.execute(command, timeout, check_exit_code, as_root)
+        if self._dryrun_enabled:
+            self._dryrun.append(command)
+        else:
+            return self.conn.execute(command, timeout, check_exit_code, as_root)
 
     def background(self, command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, as_root=False):
         return self.conn.background(command, stdout, stderr, as_root)

--- a/doc/target.rst
+++ b/doc/target.rst
@@ -145,6 +145,11 @@ Target
              thread. This will always be set to the connection for the current
              thread.
 
+.. attribute:: Target.dryrun
+
+   The accumulated dry-run commands. If dry-run mode is not active,
+   this will return the last accumulation list.
+
 .. method:: Target.connect([timeout])
    
    Establish a connection to the target. It is usually not necessary to call
@@ -217,9 +222,19 @@ Target
    :param timeout: timeout (in seconds) for the transfer; if the transfer does
        not  complete within this period, an exception will be raised.
 
+.. method:: Target.start_dryrun()
+
+   Starts dry-run mode, making further calls to Target.execute() accumulate
+   commands in a list rather than executing them.
+
+.. method:: Target.stop_dryrun()
+
+   Stops the dry-run mode.
+
 .. method:: Target.execute(command [, timeout [, check_exit_code [, as_root]]])
 
    Execute the specified command on the target device and return its output.
+   Command is not executed if dry-run mode is enabled.
 
    :param command: The command to be executed.
    :param timeout: Timeout (in seconds) for the execution of the command. If


### PR DESCRIPTION
It sometimes can be useful to enable dry-run before calling
high-level functions in order to check what individual commands
are being called (or do whatever else with them).

This patch adds dry-run with an on/off switch:
once start_dryrun() is called, every subsequent command passed to
execute() will be accumulated in a list. stop_dryrun() returns that
list and disables dry-run.