### PR TITLE
energy_probe: send signal SIGINT to caiman

### DIFF
--- a/devlib/instrument/energy_probe.py
+++ b/devlib/instrument/energy_probe.py
@@ -82,7 +82,7 @@ class EnergyProbeInstrument(Instrument):
                 'Energy Probe: Caiman exited unexpectedly with exit code {}.\n'
                 'stdout:\n{}\nstderr:\n{}'.format(self.process.returncode,
                                                   stdout, stderr))
-        os.killpg(self.process.pid, signal.SIGTERM)
+        os.killpg(self.process.pid, signal.SIGINT)
 
     def get_data(self, outfile):  # pylint: disable=R0914
         all_channels = [c.label for c in self.list_channels()]


### PR DESCRIPTION
ARM energy probe sends SIGTERM to caiman, this signal can be missed by
caiman due caiman has not registered signal handler for SIGTERM. On the
other hand, caiman registers signal handler for SIGINT, this patch is to
change to use signal SIGINT to notify caiman.

Signed-off-by: Leo Yan <leo.yan@linaro.org>