### PR TITLE
cgroups: Add support to dump fake attach events

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -177,6 +177,15 @@ cgroups_tasks_in() {
 	exit 0
 }
 
+cgroup_trace_attach_task() {
+        DST_ROOT=${1}
+        DST_PATH=${2}
+        TASKS_FILE=${3}
+
+        cat $TASKS_FILE | while read PID; do
+            echo "cgroup_attach_task_devlib: dst_root=$DST_ROOT dst_path=$DST_PATH pid=$PID" > /sys/kernel/debug/tracing/trace_marker
+        done
+}
 
 ################################################################################
 # Main Function Dispatcher
@@ -197,6 +206,9 @@ cpufreq_get_all_governors)
     ;;
 cpufreq_trace_all_frequencies)
     cpufreq_trace_all_frequencies $*
+    ;;
+cgroup_trace_attach_task)
+    cgroup_trace_attach_task $*
     ;;
 cpuidle_wake_all_cpus)
     cpuidle_wake_all_cpus $*

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -287,6 +287,11 @@ class CGroup(object):
         logging.debug('Tasks: %s', task_ids)
         return map(int, task_ids)
 
+    # Used to insert fake cgroup attach events to know existing cgroup assignments
+    def trace_cgroup_tasks(self):
+        exec_cmd = "cgroup_trace_attach_task {} {} {}".format(self.controller.hid, self.directory, self.tasks_file)
+        self.target._execute_util(exec_cmd)
+
     def add_task(self, tid):
         self.target.write_value(self.tasks_file, tid, verify=False)
 


### PR DESCRIPTION
With this its possible for users to dump the initial cgroup state into
the traces with something like the following:

cgroup = te.target.cgroups.controllers['cpuset'].cgroup('/foreground')
cgroup.trace_cgroup_tasks()

Signed-off-by: Joel Fernandes <joelaf@google.com>