### PR TITLE
Let the caller decide whether using sudo is needed or not

### DIFF
--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -236,9 +236,6 @@ class SshConnection(object):
 
     def _execute_and_wait_for_prompt(self, command, timeout=None, as_root=False, strip_colors=True, log=True):
         self.conn.prompt(0.1)  # clear an existing prompt if there is one.
-        if self.username == 'root':
-            # As we're already root, there is no need to use sudo.
-            as_root = False
         if as_root:
             command = "sudo -- sh -c '{}'".format(escape_single_quotes(command))
             if log:


### PR DESCRIPTION
Checking the username is not the right way of checking whether or not 'sudo' is needed, on some platforms the user is called 'root' but is not actually privileged (And therefore requires the use of 'su' or 'sudo').

If you really want to check whether or not sudo is needed, then you should do like WA and check `id == 0` rather than the username.