### PR TITLE
misc.py: fix syntax error introduced by 86c9b6a1c7e

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -81,6 +81,7 @@ CPU_PART_MAP = {
     },
     0x42: {  # Broadcom
         0x516: {None: 'Vulcan'},
+    },
     0x43: {  # Cavium
         0x0a1: {None: 'Thunderx'},
         0x0a2: {None: 'Thunderx81xx'},


### PR DESCRIPTION
Signed-off-by: Ionela Voinescu <ionela.voinescu@arm.com>