### PR TITLE
[RFC] module/gem5stats: parse zipped statistics file

### DIFF
--- a/devlib/module/gem5stats.py
+++ b/devlib/module/gem5stats.py
@@ -21,6 +21,8 @@ from devlib.module import Module
 from devlib.platform import Platform
 from devlib.platform.gem5 import Gem5SimulationPlatform
 from devlib.utils.gem5 import iter_statistics_dump, GEM5STATS_ROI_NUMBER, GEM5STATS_DUMP_TAIL
+from devlib.utils.zip import BufferedZippedTextReader
+from devlib.utils.misc import sync
 
 
 class Gem5ROI:
@@ -62,8 +64,6 @@ class Gem5StatsModule(Module):
     def __init__(self, target):
         super(Gem5StatsModule, self).__init__(target)
         self._current_origin = 0
-        self._stats_file_path = os.path.join(target.platform.gem5_out_dir,
-                                            'stats.txt')
         self.rois = {}
 
     def book_roi(self, label):
@@ -140,14 +140,14 @@ class Gem5StatsModule(Module):
             roi = self.rois[roi_label]
             return (roi.field in dump) and (int(dump[roi.field]) == 1)
 
-        with open(self._stats_file_path, 'r') as stats_file:
+        with self.get_input_stream() as stats_file:
             stats_file.seek(self._current_origin)
             for dump in iter_statistics_dump(stats_file):
                 active_rois = [l for l in rois_labels if roi_active(l, dump)]
                 if active_rois:
                     record = {k: dump[k] for k in keys}
                     yield (record, active_rois)
-
+                sync() # be sure to read the last dumps
 
     def reset_origin(self):
         '''
@@ -156,9 +156,19 @@ class Gem5StatsModule(Module):
         last_dump_tail = self._current_origin
         # Dump & reset stats to start from a fresh state
         self.target.execute('m5 dumpresetstats')
-        with open(self._stats_file_path, 'r') as stats_file:
+        with self.get_input_stream() as stats_file:
             for line in stats_file:
                 if GEM5STATS_DUMP_TAIL in line:
                     last_dump_tail = stats_file.tell()
         self._current_origin = last_dump_tail
 
+    def get_input_stream(self):
+        '''
+        Returns a read-only TextIOBase-like object for the statistics file.
+        '''
+        stats_filename = self.target.platform.stats_filename
+        gem5_out_dir = self.target.platform.gem5_out_dir
+        stats_path = os.path.join(gem5_out_dir, stats_filename)
+        if stats_path.endswith('.gz'):
+            return BufferedZippedTextReader(stats_path)
+        return open(stats_path, 'r')

--- a/devlib/platform/gem5.py
+++ b/devlib/platform/gem5.py
@@ -55,6 +55,7 @@ class Gem5SimulationPlatform(Platform):
         self.stdout_file = None
         self.stderr_file = None
         self.stderr_filename = None
+        self.stats_filename = None
         if self.gem5_port is None:
             # Allows devlib to pick up already running simulations
             self.start_gem5_simulation = True
@@ -126,6 +127,13 @@ class Gem5SimulationPlatform(Platform):
             # We need to keep this so we can check which port to use for the
             # telnet connection.
             self.stderr_filename = f
+
+            # Keep track of the statistics log file
+            match = re.search('--stats-file=(?P<file>\S*)', self.gem5args_args)
+            if match:
+                self.stats_filename = match.group('file') 
+            else:
+                self.stats_filename = 'stats.txt'
 
             # Start gem5 simulation
             self.logger.info("Starting the gem5 simulator")

--- a/devlib/utils/gem5.py
+++ b/devlib/utils/gem5.py
@@ -27,10 +27,7 @@ def iter_statistics_dump(stats_file):
     reading from the statistics log file.
     '''
     cur_dump = {}
-    while True:
-        line = stats_file.readline()
-        if not line:
-            break
+    for line in stats_file:
         if GEM5STATS_DUMP_TAIL in line:
             yield cur_dump
             cur_dump = {}

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -610,3 +610,11 @@ def memoized(wrapped, instance, args, kwargs):
 
     return memoize_wrapper(*args, **kwargs)
 
+def sync():
+    """Flushes OS buffers in UNIX systems"""
+    if hasattr(os, 'sync'):
+        os.sync()
+    elif os.name != 'nt':
+        os.system('sync')
+    else:
+        pass # Windows, hope for the best

--- a/devlib/utils/zip.py
+++ b/devlib/utils/zip.py
@@ -1,0 +1,175 @@
+#    Copyright 2017 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import zlib
+from io import FileIO, UnsupportedOperation, TextIOBase
+try:
+    from cStringIO import StringIO
+except:
+    from StringIO import StringIO
+
+
+class BufferedZippedTextReader(TextIOBase):
+
+    def __init__(self, file_path, window_size=16384, wbits=47):
+        '''
+        parameters:
+            :file_path: path to the archive.
+            :window_size: size of buffer holding compressed data (bytes).
+            :wbits: configuration parameter for zlib decompressor.
+        '''
+        self.file_path = file_path
+        self.in_stream = FileIO(self.file_path, 'r')
+        self.window_size = window_size
+        self.wbits = wbits
+        self._reset()
+        self.mode = 'r'
+
+    def tell(self):
+        '''
+        Returns the current posititon of cursor in the extracted file. 
+        Returns -1 when EOF has been reached.
+        '''
+        return self.cur_pos
+   
+    def seek(self, offset, whence=0):
+        '''
+        Moves cursor to specified offset in extracted file.
+
+        parameters:
+            :offset: the absolute or relative offset to which the file cursor
+                     must be moved.
+            :whence: default value is 0 meaning absolute file positionning. 
+                     1 means seek() is relative to current position. Other 
+                     strategies are not yet implemented.
+        '''
+        if whence == 0:
+            target_pos = offset
+        elif whence == 1:
+            target_pos = self.tell() + offset
+        else:
+            raise ValueError('Invalid whence: {}'.format(whence))
+        if target_pos < self.tell():
+            self._reset()
+        while self.tell() != target_pos and self.tell() != -1:
+            self.char_iterator.next()
+        return self.tell()
+
+    def readline(self, size=-1):
+        line_writer = StringIO()
+        char_count = 0
+        while char_count < size or size < 0:
+            c = self.char_iterator.next()
+            if c == '\n' or not c:
+                break
+            line_writer.write(c)
+            char_count += 1
+        return line_writer.getvalue()
+
+    def readlines(self, size=-1):
+        return self.read(size).split('\n')
+
+    def readall(self):
+        res = StringIO()
+        for c in self.char_iterator:
+            res.write(c)
+        return res.getvalue()
+
+    def read(self, size=-1):
+        if size == -1 or size == None:
+            return self.readall()
+        i = 0
+        res = StringIO()
+        while self.tell() != -1 and i < size:
+            c = self.char_iterator.next()
+            res.write(c)
+            i += 1
+        return res.getvalue()
+    
+    def close(self):
+        super(TextIOBase, self).close()
+        self.in_stream.close()
+
+    def __enter__(self):
+        self._reset()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        return self.readline()
+
+    def fileno(self):
+        return self.in_stream.fileno()
+
+    def isatty(self):
+        return self.in_stream.isatty()
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return True
+
+    def detach(self, *args, **kwargs):
+        raise UnsupportedOperation('Cannot detach underlying buffer.')
+
+    # Stub write-related methods of TextIOBase
+    def writable(self):
+        return False
+
+    def write(self, *args, **kwargs):
+        raise IOError('Cannot write in read-only stream')
+    
+    def writelines(self, *args, **kwargs):
+        raise IOError('Cannot write in read-only stream')
+    
+    def truncate(self, *args, **kwargs):
+        raise IOError('Cannot truncate read-only stream')
+
+    def flush(self):
+        pass
+
+    def _iter_buff(self):
+        while True:
+            to_unzip = self.in_stream.read(self.window_size)
+            buff_writer = StringIO()
+            while to_unzip:
+                buff_writer.write(self.decompressor.decompress(to_unzip))
+                to_unzip = self.decompressor.unconsumed_tail
+            buff = buff_writer.getvalue()
+            if buff:
+                yield buff
+            else:
+                return
+
+    def _iter_char(self):
+        for buff in self.buff_iterator:
+            for c in buff:
+                self.cur_pos += 1
+                yield c
+        self.cur_pos = -1
+    
+    def _reset(self):
+        self.cur_pos = 0
+        self.in_stream.seek(0) 
+        self.decompressor = zlib.decompressobj(self.wbits)
+        self.buff_iterator = self._iter_buff()
+        self.char_iterator = self._iter_char()
+


### PR DESCRIPTION
This is an attempt to parse gem5's statistics file with on-line compression. The PR should probably **not** be merged in the current state, I submitted it to collect ideas and feedback. 

I think the overall state of the generic zipped text file reader and the connection with the existing gem5 infrastructure added with this PR are probably ok but there is still another gem5-specific issue that might be worth tackling. Tests on my machines revealed that, when using gem5 with on-line compression of stats log, dumps often need some time to be written into the output .gz file. Consequently it happens that calls to `gem5stats.match()` right after the end of a ROI can miss some of the latest dumps which have not been written in the statistics file yet. I tried to mitigate this issue by "syncing" the host OS between dump reads but it does not seem to be enough -- that's very likely an internal gem5 issue. Adding a small delay at the begining of `gem5stats.match()` could probably solve the issue but is looks quiet hacky.

Any ideas or suggestions to fix that more cleanly are very welcome :)