### PR TITLE
gem5: make explicit power modelling parameters

### DIFF
--- a/devlib/instrument/gem5power.py
+++ b/devlib/instrument/gem5power.py
@@ -37,6 +37,8 @@ class Gem5PowerInstrument(Instrument):
         '''
         if not isinstance(target.platform, Gem5SimulationPlatform):
             raise TargetError('Gem5PowerInstrument requires a gem5 platform')
+        if not target.platform.power_models_dir:
+            raise TargetError('Power modelling not enabled in Gem5SimulationPlatform')
         if not target.has('gem5stats'):
             raise TargetError('Gem5StatsModule is not loaded')
         super(Gem5PowerInstrument, self).__init__(target)

--- a/devlib/platform/gem5.py
+++ b/devlib/platform/gem5.py
@@ -37,7 +37,8 @@ class Gem5SimulationPlatform(Platform):
                  big_core=None,
                  model=None,
                  modules=None,
-                 gem5_telnet_port=None):
+                 gem5_telnet_port=None,
+                 power_models_dir=None):
 
         # First call the parent class
         super(Gem5SimulationPlatform, self).__init__(name, core_names, core_clusters,
@@ -52,6 +53,7 @@ class Gem5SimulationPlatform(Platform):
         self.gem5_interact_dir = '/tmp' # Host directory
         self.executable_dir = None # Device directory
         self.working_dir = None # Device directory
+        self.power_models_dir = power_models_dir # Location of the power models
         self.stdout_file = None
         self.stderr_file = None
         self.stderr_filename = None
@@ -126,6 +128,11 @@ class Gem5SimulationPlatform(Platform):
             # We need to keep this so we can check which port to use for the
             # telnet connection.
             self.stderr_filename = f
+
+            # Enable power modelling if required
+            if self.power_models_dir:
+                os.environ['POWER_MODEL_ROOT'] = self.power_models_dir
+                self.gem5args_args += ' --power-model'
 
             # Start gem5 simulation
             self.logger.info("Starting the gem5 simulator")


### PR DESCRIPTION
It is currently assumed in the gem5 power instrument that the platform
has been appropriately configured to bind gem5 with power models. This
makes this configuration explicit in Gem5SimulationPlatform and extends 
the power instrument setup with a check on that.