### PR TITLE
module/cgroups: robustify task freezer

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -177,6 +177,23 @@ cgroups_tasks_in() {
 	exit 0
 }
 
+cgroups_freezer_set_state() {
+    STATE=${1}
+    SYSFS_ENTRY=${2}/freezer.state
+
+    # Set the state of the freezer
+    echo $STATE > $SYSFS_ENTRY
+    
+    # And check it applied cleanly
+    for i in `seq 1 10`; do
+        [ $($CAT $SYSFS_ENTRY) = $STATE ] && exit 0
+        sleep 1
+    done
+
+    # We have an issue
+    echo "ERROR: Freezer stalled while changing state to \"$STATE\"." >&2
+    exit 1
+}
 
 ################################################################################
 # Main Function Dispatcher
@@ -212,6 +229,9 @@ cgroups_tasks_move)
 	;;
 cgroups_tasks_in)
 	cgroups_tasks_in $*
+	;;
+cgroups_freezer_set_state)
+	cgroups_freezer_set_state $*
 	;;
 ftrace_get_function_stats)
     ftrace_get_function_stats

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -466,11 +466,11 @@ class CgroupsModule(Module):
         if freezer is None:
             raise RuntimeError('freezer cgroup controller not present')
         freezer_cg = freezer.cgroup('/DEVLIB_FREEZER')
-        thawed_cg = freezer.cgroup('/')
+        cmd = 'cgroups_freezer_set_state {{}} {}'.format(freezer_cg.directory)
 
         if thaw:
             # Restart froozen tasks
-            freezer_cg.set(state='THAWED')
+            freezer.target._execute_util(cmd.format('THAWED'), as_root=True)
             # Remove all tasks from freezer
             freezer.move_all_tasks_to('/')
             return
@@ -482,7 +482,7 @@ class CgroupsModule(Module):
         tasks = freezer.tasks('/')
 
         # Freeze all tasks
-        freezer_cg.set(state='FROZEN')
+        freezer.target._execute_util(cmd.format('FROZEN'), as_root=True)
 
         return tasks
 


### PR DESCRIPTION
The `set()` method of the CGroup class used to freeze tasks relies on target's `write_value()`. Sometimes, the freezing procedure takes some time and the call to `write_value()` in `set()` fails by reading `FREEZING` while it expected `FROZEN` (reported in issue #136). To avoid this issue, this PR allows `write_value()` to retry the check several times before raising an exception.