### PR TITLE
module/gem5stats: enhance match() with regex support

### DIFF
--- a/devlib/instrument/gem5power.py
+++ b/devlib/instrument/gem5power.py
@@ -72,7 +72,7 @@ class Gem5PowerInstrument(Instrument):
             sites_to_match = [self.site_mapping.get(s, s) for s in active_sites]
             for rec, rois in self.target.gem5stats.match_iter(sites_to_match,
                     [self.roi_label], self._base_stats_dump):
-                writer.writerow([float(rec[s]) for s in active_sites])
+                writer.writerow([rec[s] for s in active_sites])
         return MeasurementsCsv(outfile, self.active_channels, self.sample_rate_hz)
 
     def reset(self, sites=None, kinds=None, channels=None):


### PR DESCRIPTION
The current implementation of match() in the gem5stats module returns
records matching exactly the specified keys. This PR changes this
behaviour by matching keys over regular expressions, hence resulting in
a much more powerful match() implementation.