### PR TITLE
Logcat monitor

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -14,7 +14,7 @@ from devlib.module import get_module
 from devlib.platform import Platform
 from devlib.exception import TargetError, TargetNotRespondingError, TimeoutError
 from devlib.utils.ssh import SshConnection
-from devlib.utils.android import AdbConnection, AndroidProperties, adb_command, adb_disconnect
+from devlib.utils.android import AdbConnection, AndroidProperties, LogcatMonitor, adb_command, adb_disconnect
 from devlib.utils.misc import memoized, isiterable, convert_new_lines, merge_lists
 from devlib.utils.misc import ABI_MAP, get_cpu_name, ranges_to_list, escape_double_quotes
 from devlib.utils.types import integer, boolean, bitmask, identifier, caseless_string
@@ -1155,6 +1155,9 @@ class AndroidTarget(Target):
 
     def clear_logcat(self):
         adb_command(self.adb_name, 'logcat -c', timeout=30)
+
+    def get_logcat_monitor(self, regexps=None):
+        return LogcatMonitor(self, regexps)
 
     def adb_kill_server(self, timeout=30):
         adb_command(self.adb_name, 'kill-server', timeout)

--- a/devlib/trace/logcat.py
+++ b/devlib/trace/logcat.py
@@ -1,0 +1,58 @@
+import os
+import re
+import shutil
+
+from devlib.trace import TraceCollector
+from devlib.utils.android import LogcatMonitor
+
+class LogcatCollector(TraceCollector):
+
+    def __init__(self, target, regexps=None):
+        super(LogcatCollector, self).__init__(target)
+        self.regexps = regexps
+        self._collecting = False
+        self._prev_log = None
+
+    def reset(self):
+        """
+        Clear Collector data but do not interrupt collection
+        """
+        if not self._monitor:
+            return
+
+        if self._collecting:
+            self._monitor.clear_log()
+        elif self._prev_log:
+            os.remove(self._prev_log)
+            self._prev_log = None
+
+    def start(self):
+        """
+        Start collecting logcat lines
+        """
+        self._monitor = LogcatMonitor(self.target, self.regexps)
+        if self._prev_log:
+            # Append new data collection to previous collection
+            self._monitor.start(self._prev_log)
+        else:
+            self._monitor.start()
+
+        self._collecting = True
+
+    def stop(self):
+        """
+        Stop collecting logcat lines
+        """
+        if not self._collecting:
+            raise RuntimeError('Logcat monitor not running, nothing to stop')
+
+        self._monitor.stop()
+        self._collecting = False
+        self._prev_log = self._monitor.logfile
+
+    def get_trace(self, outfile):
+        """
+        Output collected logcat lines to designated file
+        """
+        # copy self._monitor.logfile to outfile
+        shutil.copy(self._monitor.logfile, outfile)


### PR DESCRIPTION
The code could probably do with some cleanup, but I wanted to get some feedback before investing too much time into it.

This was made due to a need to parse logcat with lines that can come out of order. Furthermore, most of the logcat parsing done in LISA was copy-pasted from one workload to another, so I wanted to centralize that.

The idea here is to have a thread that reads from logcat, and it can also look for certain regexps (by default '.*', so every line will be logged). We can then search for all the lines matching a given regexp. The general use case is:

```
# All regexps that will be used during the workload execution
my_regexps = [...]

logcat = target.logcat_monitor(my_regexps)
logcat.start()

my_workload.run()

logcat.search(WORKLOAD_START_REGEXP)
print "workload started !"

logcat.search(WORKLOAD_END_REGEXP)
print "workload ended !"

logcat.stop()
```