### PR TITLE
utils/android: Add grant_app_permissions

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -445,6 +445,23 @@ def adb_command(device, command, timeout=None,adb_server=None):
     output, _ = check_output(full_command, timeout, shell=True)
     return output
 
+def grant_app_permissions(target, package):
+    """
+    Grant an app all the permissions it may ask for
+    """
+    dumpsys = target.execute('dumpsys package {}'.format(package))
+
+    permissions = re.search(
+        'requested permissions:\s*(?P<permissions>(android.permission.+\s*)+)', dumpsys
+    )
+    permissions = permissions.group('permissions').replace(" ", "").splitlines()
+
+    for permission in permissions:
+        try:
+            target.execute('pm grant {} {}'.format(package, permission))
+        except TargetError:
+            logger.debug('Cannot grant {}'.format(permission))
+
 
 # Messy environment initialisation stuff...
 


### PR DESCRIPTION
This is mostly useful to avoid having to manually click/tap on the permission requests that may pop up when opening apps, which would ruin automation