### PR TITLE
instrument/frames: Fix parsing MeasurementsCsv

### DIFF
--- a/devlib/instrument/frames.py
+++ b/devlib/instrument/frames.py
@@ -44,7 +44,7 @@ class FramesInstrument(Instrument):
         self.collector.process_frames(raw_outfile)
         active_sites = [chan.label for chan in self.active_channels]
         self.collector.write_frames(outfile, columns=active_sites)
-        return MeasurementsCsv(outfile, self.active_channels, self.sample_rate_hz)
+        return MeasurementsCsv(outfile, sample_rate_hz=self.sample_rate_hz)
 
     def _init_channels(self):
         raise NotImplementedError()


### PR DESCRIPTION
The collector's write_frames method uses a fixed column order, only using the
'columns' param as a filter i.e. if its columns are ['a', 'b', 'c'] and you pass
columns=['c', 'a'], the output columns will be ['a', 'c'].

Therefore passing self.active_channels breaks MeasurementsCsv parsing when its
order does not match the collector's column order.

Since the collector writes a header in the CSV file, just pass columns=None to
MeasurementsCsv so it will parse that header to detect the column order.