### PR TITLE
android: Add AndroidScreen class with orientation methods

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -14,7 +14,8 @@ from devlib.module import get_module
 from devlib.platform import Platform
 from devlib.exception import TargetError, TargetNotRespondingError, TimeoutError
 from devlib.utils.ssh import SshConnection
-from devlib.utils.android import AdbConnection, AndroidProperties, LogcatMonitor, adb_command, adb_disconnect
+from devlib.utils.android import (AdbConnection, AndroidProperties, LogcatMonitor,
+                                  adb_command, adb_disconnect, AndroidScreen)
 from devlib.utils.misc import memoized, isiterable, convert_new_lines, merge_lists
 from devlib.utils.misc import ABI_MAP, get_cpu_name, ranges_to_list, escape_double_quotes
 from devlib.utils.types import integer, boolean, bitmask, identifier, caseless_string
@@ -927,6 +928,7 @@ class AndroidTarget(Target):
                                             shell_prompt=shell_prompt,
                                             conn_cls=conn_cls)
         self.package_data_directory = package_data_directory
+        self.screen = AndroidScreen(self)
 
     def reset(self, fastboot=False):  # pylint: disable=arguments-differ
         try:

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -616,7 +616,7 @@ class LogcatMonitor(threading.Thread):
         with self._datalock:
             while not self._lines.empty():
                 self._lines.get()
-                
+
             with open(self._logfile, 'w') as fh:
                 pass
 
@@ -671,3 +671,54 @@ class LogcatMonitor(threading.Thread):
             return [self._found]
         else:
             raise RuntimeError('Logcat monitor timeout ({}s)'.format(timeout))
+
+class AndroidScreen(object):
+    """
+    Class encapsulating screen operations for Android devices
+    """
+    def __init__(self, target):
+        self.target = target
+
+    def get_orientation(self):
+        """
+        Get current screen orientation. Can be passed back to set_orientation.
+        """
+        accelerometer_rotation = int(self.target.execute(
+            'settings get system accelerometer_rotation'))
+        if accelerometer_rotation == 1:
+            return 'auto'
+
+        user_rotation = int(self.target.execute(
+            'settings get system user_rotation'))
+        if user_rotation == 1:
+            return 'landscape'
+        else:
+            return 'portrait'
+
+    def set_orientation(self, orientation='portrait'):
+        """
+        Set screen orientation mode
+
+        :param orientation: One of 'portrait', 'landscape' or 'auto'. Auto means
+                            use the accelerometer.
+        :type orientation: str
+        """
+        valid_orientations = ('portrait', 'landscape', 'auto')
+        if orientation not in valid_orientations:
+            raise ValueError('Invalid orientation: chose from {}'
+                             .format(valid_orientations))
+
+        if orientation == 'auto':
+            # Force portrait mode before activating auto rotation
+            self.target.execute('settings put system user_rotation 0')
+            self.target.execute('settings put system accelerometer_rotation 1')
+        else:
+            if orientation == 'landscape':
+                user_rotation = 1
+            else:
+                user_rotation = 0
+
+            # Disable automatic rotation before setting fixed orientation
+            self.target.execute('settings put system accelerometer_rotation 0')
+            self.target.execute('settings put system user_rotation {}'
+                                .format(user_rotation))


### PR DESCRIPTION
This can be used to save, set and restore the screen
orientation.

This can be useful for ensuring the reproducibility of results that
depend on the actual content that was rendered. A simple example of
this is that a device with an OLED screen uses measurably more energy
playing a plain-white Youtube video if it is in landscape orentation,
due to having more white pixels lit up.