### PR TITLE
Module initialization optimizations.

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -196,6 +196,22 @@ cgroups_freezer_set_state() {
 }
 
 ################################################################################
+# Misc
+################################################################################
+
+read_tree_values() {
+    PATH=$1
+    MAXDEPTH=$2
+
+    PATHS=$($BUSYBOX find $PATH -follow -maxdepth $MAXDEPTH)
+    if [ ${#PATHS[@]} -eq 0 ]; then
+        echo "ERROR: '$1' does not exist"
+    else
+        $BUSYBOX grep -s '' $PATHS
+    fi
+}
+
+################################################################################
 # Main Function Dispatcher
 ################################################################################
 
@@ -235,6 +251,9 @@ cgroups_freezer_set_state)
 	;;
 ftrace_get_function_stats)
     ftrace_get_function_stats
+    ;;
+read_tree_values)
+	read_tree_values $*
     ;;
 *)
     echo "Command [$CMD] not supported"

--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -196,6 +196,19 @@ cgroups_freezer_set_state() {
 }
 
 ################################################################################
+# Hotplug
+################################################################################
+
+hotplug_online_all() {
+    PATHS=(/sys/devices/system/cpu/cpu[0-9]*)
+    for path in "${PATHS[@]}"; do
+        if [ $(cat $path/online) -eq 0 ]; then
+            echo 1 > $path/online
+        fi
+    done
+}
+
+################################################################################
 # Misc
 ################################################################################
 
@@ -251,6 +264,9 @@ cgroups_freezer_set_state)
 	;;
 ftrace_get_function_stats)
     ftrace_get_function_stats
+    ;;
+hotplug_online_all)
+	hotplug_online_all
     ;;
 read_tree_values)
 	read_tree_values $*

--- a/devlib/module/__init__.py
+++ b/devlib/module/__init__.py
@@ -56,7 +56,7 @@ class Module(object):
 
     def __init__(self, target):
         self.target = target
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(self.name)
 
 
 class HardRestModule(Module):  # pylint: disable=R0921

--- a/devlib/module/hotplug.py
+++ b/devlib/module/hotplug.py
@@ -21,7 +21,8 @@ class HotplugModule(Module):
         return target.path.join(cls.base_path, cpu, 'online')
 
     def online_all(self):
-        self.online(*range(self.target.number_of_cpus))
+        self.target._execute_util('hotplug_online_all',
+                                  as_root=self.target.is_rooted)
 
     def online(self, *args):
         for cpu in args:

--- a/doc/target.rst
+++ b/doc/target.rst
@@ -327,6 +327,32 @@ Target
        some sysfs entries silently failing to set the written value without
        returning an error code.
 
+.. method:: Target.read_tree_values(path, depth=1, dictcls=dict):
+
+   Read values of all sysfs (or similar) file nodes under ``path``, traversing
+   up to the maximum depth ``depth``.
+
+   Returns a nested structure of dict-like objects (``dict``\ s by default) that
+   follows the structure of the scanned sub-directory tree. The top-level entry
+   has a single item who's key is ``path``. If ``path`` points to a single file,
+   the value of the entry is the value ready from that file node. Otherwise, the
+   value is a dict-line object  with a key for every entry under ``path``
+   mapping onto its value or further dict-like objects as appropriate.
+
+   :param path: sysfs path to scan
+   :param depth: maximum depth to descend
+   :param dictcls: a dict-like type to be used for each level of the hierarchy.
+
+.. method:: Target.read_tree_values_flat(path, depth=1):
+
+   Read values of all sysfs (or similar) file nodes under ``path``, traversing
+   up to the maximum depth ``depth``.
+
+   Returns a dict mapping paths of file nodes to corresponding values.
+
+   :param path: sysfs path to scan
+   :param depth: maximum depth to descend
+
 .. method:: Target.reset()
 
    Soft reset the target. Typically, this means executing ``reboot`` on the


### PR DESCRIPTION
This pull request contains a number of module initialization optimizations that
significantly reduce the time it takes to start a new run. Testing with a
USB-connected Android device, the time for a run of a single uninstrumented
dhrystone  was reduced from ~75 to ~20 seconds.

This reduction is a achieved by reducing the number of calls that need to be
made to a target in order to initialize module state. This done by introducing
APIs for extracting values from an entire sysfs sub-tree  in a single call.