### PR TITLE
shuilt: re-introduce speedup

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -223,7 +223,10 @@ read_tree_values() {
     PATHS=$($BUSYBOX find $BASEPATH -follow -maxdepth $MAXDEPTH)
     i=0
     for path in $PATHS; do
-            i=$(expr $i + 1)
+        i=$(expr $i + 1)
+        if [ $i -gt 1 ]; then
+            break;
+        fi
     done
     if [ $i -gt 1 ]; then
         $BUSYBOX grep -s '' $PATHS


### PR DESCRIPTION
The previous fix for read_tree_values fixed the issue with sh not
supporting arrays, but looping over paths and counting them. Hover each
count increment requires spawning a subshell. For a large number of paths,
this can eat away any performance benefits of using read_tree_values.

Since we only care whether the count is greater than one, detect that
and break out of the loop early to re-introduce the performance
improvement.