### PR TITLE
ANSI escape sequences stripping fixes for gem5

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -474,8 +474,8 @@ def which(name):
             return None
 
 
-_bash_color_regex = re.compile('\x1b\\[[0-9;]+m')
-
+# This matches most ANSI escape sequences, not just colors
+_bash_color_regex = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
 
 def strip_bash_colors(text):
     return _bash_color_regex.sub('', text)

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -444,7 +444,7 @@ class Gem5Connection(TelnetConnection):
         self._check_ready()
 
         result = self._gem5_shell("ls {}".format(source))
-        files = result.split()
+        files = strip_bash_colors(result).split()
 
         for filename in files:
             dest_file = os.path.basename(filename)


### PR DESCRIPTION
Fix gem5 implementation of pull() to properly strip ANSI sequences from the result of running 'ls' internally. Also expand the number of sequences that get stripped.