### PR TITLE
AndroidTarget: prevent concurrent invocations of 'logcat -c'

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -952,6 +952,7 @@ class AndroidTarget(Target):
                                             shell_prompt=shell_prompt,
                                             conn_cls=conn_cls)
         self.package_data_directory = package_data_directory
+        self.clear_logcat_lock = threading.Lock()
 
     def reset(self, fastboot=False):  # pylint: disable=arguments-differ
         try:
@@ -1184,7 +1185,8 @@ class AndroidTarget(Target):
         adb_command(self.adb_name, command, timeout=timeout)
 
     def clear_logcat(self):
-        adb_command(self.adb_name, 'logcat -c', timeout=30)
+        with self.clear_logcat_lock:
+            adb_command(self.adb_name, 'logcat -c', timeout=30)
 
     def get_logcat_monitor(self, regexps=None):
         return LogcatMonitor(self, regexps)


### PR DESCRIPTION
'adb logcat -c' has been observed to fail when called twice concurrently. Rather
than requiring all devlib users to fix their usage patterns, let's just delay
whenever clear_logcat is called twice.