### PR TITLE
AndroidTarget: Add boolean 'state' to airplane mode intent broadcast

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1252,9 +1252,11 @@ class AndroidTarget(Target):
         root_required = self.get_sdk_version() > 23
         if root_required and not self.is_rooted:
             raise TargetError('Root is required to toggle airplane mode on Android 7+')
+        mode = int(boolean(mode))
         cmd = 'settings put global airplane_mode_on {}'
-        self.execute(cmd.format(int(boolean(mode))))
-        self.execute('am broadcast -a android.intent.action.AIRPLANE_MODE', as_root=root_required)
+        self.execute(cmd.format(mode))
+        self.execute('am broadcast -a android.intent.action.AIRPLANE_MODE '
+                     '--ez state {}'.format(mode), as_root=root_required)
 
     def get_auto_rotation(self):
         cmd = 'settings get system accelerometer_rotation'


### PR DESCRIPTION
Recently I've been seeing some errors with enabling airplane mode on
hikey960 - firstly I get a 'broken pipe' error followed by a 'cmd:
Can't find service: settings'. This missing boolean was the first
thing I found that had changed wrt. the code I used to use, and
adding it back appears to fix the issue.