### PR TITLE
android: Use pexpect for LogcatMonitor

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -442,13 +442,16 @@ def adb_list_devices(adb_server=None):
     return devices
 
 
-def adb_command(device, command, timeout=None,adb_server=None):
+def get_adb_command(device, command, timeout=None,adb_server=None):
     _check_env()
     device_string = ""
     if adb_server != None:
         device_string = ' -H {}'.format(adb_server)
     device_string += ' -s {}'.format(device) if device else ''
-    full_command = "adb{} {}".format(device_string, command)
+    return "adb{} {}".format(device_string, command)
+
+def adb_command(device, command, timeout=None,adb_server=None):
+    full_command = get_adb_command(device, command, timeout, adb_server)
     logger.debug(full_command)
     output, _ = check_output(full_command, timeout, shell=True)
     return output


### PR DESCRIPTION
I wrote this for another reason which turned out not to be necessary. However it turns out that the current LogcatMonitor can't be killed with Ctrl+C while it's in the `threading.Event.wait` in `wait_for`, which is irritating. So I'm submitting this now. It also reduces lines of code which I guess is Good.