### PR TITLE
shutils: look for an exact match of a cgroup

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -131,7 +131,7 @@ cgroups_run_into() {
 	  fi
 
 	  $FIND $CGMOUNT -type d -mindepth 1 | \
-	  $GREP "$CGP" | \
+	  $GREP -e "^$CGMOUNT$CGP$" | \
 	  while read CGPATH; do
 		  # Move this shell into that control group
 		  echo $$ > $CGPATH/cgroup.procs


### PR DESCRIPTION
When running a command into a cgroup we want to make sure that the command is
only run inside the intended cgroup. If there is a hierarchy of cgroups named
with a common prefix, the script will move it to all matching cgroup and as a
result the task will end up running always at lowest level. For example, if we
have the following hierarchy of cgroups:

````
  "/"
   |__ "/tg1"
         |__ "/tg1/tg1_1"
````

and we want to run something in cgroup "/tg1/", the lowest levels will match the
regexp and the task will ultimately be moved to "/tg1/tg1_1".

This patch fixes the issue by requiring the absolute path of the specified
cgroup to match exactly.