### PR TITLE
shutils: fail if cgroup path does not match exactly

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -124,7 +124,7 @@ cgroups_run_into() {
 
 	  # Check if the required CGroup exists
 	  $FIND $CGMOUNT -type d -mindepth 1 | \
-	  $GREP "$CGP" &>/dev/null
+	  $GREP "^$CGMOUNT$CGP" &>/dev/null
 	  if [ $? -ne 0 ]; then
 		echo "ERROR: could not find any $CGP cgroup under $CGMOUNT"
 		exit 1


### PR DESCRIPTION
As of "f3b04fc shutils: look for an exact match of a cgroup", the cgroup name is
expected to match the exact path from the mount name to the actual cgroup the
command has to be run into. In case of no matches a failure should be raised.