### PR TITLE
shutils: consider different hierarchies when running command into cgr…

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -124,14 +124,14 @@ cgroups_run_into() {
 
 	  # Check if the required CGroup exists
 	  $FIND $CGMOUNT -type d -mindepth 1 | \
-	  $GREP "$CGP" &>/dev/null
+	  $GREP -E "^$CGMOUNT/devlib_cgh[0-9]{1,2}$CGP" &>/dev/null
 	  if [ $? -ne 0 ]; then
 		echo "ERROR: could not find any $CGP cgroup under $CGMOUNT"
 		exit 1
 	  fi
 
 	  $FIND $CGMOUNT -type d -mindepth 1 | \
-	  $GREP -e "^$CGMOUNT$CGP$" | \
+	  $GREP -E "^$CGMOUNT/devlib_cgh[0-9]{1,2}$CGP$" | \
 	  while read CGPATH; do
 		  # Move this shell into that control group
 		  echo $$ > $CGPATH/cgroup.procs


### PR DESCRIPTION
…oups

The target platform can have different hierarchies with different cgroup
controllers mounted. If we have a cgroup that uses different controllers
belonging to different hierarchies, that cgroup will be present under the
different hierarchies. Therefore, in such cases we need to take into all those
paths having that cgroup and move the task into all of them.