### PR TITLE
target: fix broadcast_media_mounted for Android O

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1238,8 +1238,9 @@ class AndroidTarget(Target):
         """
         Force a re-index of the mediaserver cache for the specified directory.
         """
-        command = 'am broadcast -a  android.intent.action.MEDIA_MOUNTED -d file://'
-        self.execute(command + dirpath, as_root=as_root)
+        command = 'am broadcast -a  android.intent.action.MEDIA_MOUNTED -d file://{} '\
+                  '-n com.android.providers.media/.MediaScannerReceiver'
+        self.execute(command.format(dirpath), as_root=as_root)
 
     def install_executable(self, filepath, with_name=None):
         self._ensure_executables_directory_is_writable()


### PR DESCRIPTION
In an effort to reduce thrashing, "implicit" broadcasts are no longer
allowed in Android O. See:

https://issuetracker.google.com/issues/36496703#comment7

This impacts MEDIA_MOUNTED broadcasts. To get around this issue,
explicitly specify the component the broadcast is targeted at.