### PR TITLE
gem5power: fix gem5power get_data after channel rename

### DIFF
--- a/devlib/instrument/gem5power.py
+++ b/devlib/instrument/gem5power.py
@@ -72,7 +72,7 @@ class Gem5PowerInstrument(Instrument):
             sites_to_match = [self.site_mapping.get(s, s) for s in active_sites]
             for rec, rois in self.target.gem5stats.match_iter(sites_to_match,
                     [self.roi_label], self._base_stats_dump):
-                writer.writerow([rec[s] for s in active_sites])
+                writer.writerow([rec[s] for s in sites_to_match])
         return MeasurementsCsv(outfile, self.active_channels, self.sample_rate_hz)
 
     def reset(self, sites=None, kinds=None, channels=None):


### PR DESCRIPTION
active_sites is used instead of sites_to_match and that
results in "KeyError: 'timestamp'" when parsing the
statistics file. 'sim_seconds' should be used instead
of 'timestamp'.

Signed-off-by: Ionela Voinescu <ionela.voinescu@arm.com>