### PR TITLE
LinuxTarget: Port forbidden char fix from WA2

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -782,7 +782,8 @@ class LinuxTarget(Target):
     def model(self):
         if self.file_exists("/proc/device-tree/model"):
             raw_model = self.execute("cat /proc/device-tree/model")
-            return '_'.join(raw_model.split()[:2])
+            device_model_to_return = '_'.join(raw_model.split()[:2])
+            return device_model_to_return.rstrip(' \t\r\n\0')
         return None
 
     def __init__(self,


### PR DESCRIPTION
Fix for Chromebook Plus and possibly other devices - removes forbidden
characters from the device_model such as the null character.