### PR TITLE
target: LocalLinuxTarget: Populate _file_transfer_cache

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1638,6 +1638,7 @@ class LocalLinuxTarget(LinuxTarget):
     def _resolve_paths(self):
         if self.working_directory is None:
             self.working_directory = '/tmp'
+        self._file_transfer_cache = self.path.join(self.working_directory, '.file-cache')
         if self.executables_directory is None:
             self.executables_directory = '/tmp'
 


### PR DESCRIPTION
Since 1e34390b990f1d85b083d31693d71fad5c9f28a6, AndroidTarget and
LinuxTarget share the same code for `push` and `pull`. However,
these methods expect a `_file_transfer_cache` field to be present.
It is currently populated in `_resolve_paths` for AndroidTarget
and LinuxTarget, but not for LocalLinuxTarget.

Since LocalLinuxTarget inherits its `push` & `pull` from LinuxTarget,
this causes an exception. This commit fixes it by adding an assignment
to `_file_transfer_cache` in `LocalLinuxTarget:_resolves_paths`.

This is a simple fix, and the actual push/pull behaviour of that local
target class could be improved in regards to that transfer cache, but
it should be good enough for now.