### PR TITLE
LocalLinuxTarget: fix executables folder location

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1644,10 +1644,10 @@ class LocalLinuxTarget(LinuxTarget):
 
     def _resolve_paths(self):
         if self.working_directory is None:
-            self.working_directory = '/tmp'
+            self.working_directory = '/tmp/devlib-target'
         self._file_transfer_cache = self.path.join(self.working_directory, '.file-cache')
         if self.executables_directory is None:
-            self.executables_directory = '/tmp'
+            self.executables_directory = '/tmp/devlib-target/bin'
 
 
 def _get_model_name(section):


### PR DESCRIPTION
Since:
   cafc0a4 target: do not create shutil in package directory
we generate 'shutils' in /tmp, which is also the executables_path
used used by deafult by a LocalLinuxTarget.

This ultimately results into a:

   self.install(shutils_ofile)
      ...
         shutil.copy(source, dest)

raising an exception since source == dest.

Let's fix this by setting /tmp/devlib-target as a default base path for
all devlib deployed stuff into a localhost target.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>