### PR TITLE
utils/misc: Check if identifier starts with a number

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -523,7 +523,9 @@ TRANS_TABLE = string.maketrans(BAD_CHARS, '_' * len(BAD_CHARS))
 
 def to_identifier(text):
     """Converts text to a valid Python identifier by replacing all
-    whitespace and punctuation."""
+    whitespace and punctuation and adding a prefix if starting with a digit"""
+    if text[:1].isdigit():
+        text = '_' + text
     return re.sub('_+', '_', text.translate(TRANS_TABLE))
 
 


### PR DESCRIPTION
Now ensures that the given text does not start with a digit and if so
prefix an underscore to ensure a valid python identifier.