### PR TITLE
target: fix get_rotation() when null

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1370,7 +1370,11 @@ class AndroidTarget(Target):
 
     def get_rotation(self):
         cmd = 'settings get system user_rotation'
-        return int(self.execute(cmd).strip())
+        res = self.execute(cmd).strip()
+        try:
+            return int(res)
+        except ValueError:
+            return None
 
     def set_rotation(self, rotation):
         if not 0 <= rotation <= 3:


### PR DESCRIPTION
Some targets don't seem to set system.user_rotation, resulting in "null"
being returned. This exploded on integer conversion. Handle this case by
returning the Python equivalent, None.