### PR TITLE
utils/misc: fix to_identifier for unicode

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -526,7 +526,7 @@ def to_identifier(text):
     whitespace and punctuation and adding a prefix if starting with a digit"""
     if text[:1].isdigit():
         text = '_' + text
-    return re.sub('_+', '_', text.translate(TRANS_TABLE))
+    return re.sub('_+', '_', str(text).translate(TRANS_TABLE))
 
 
 def unique(alist):


### PR DESCRIPTION
string.translate can fail when passed a unicode object; explicitly str()
it first to avoid this.