### PR TITLE
utils/android: Append platform-tools at the end of PATH

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -491,7 +491,7 @@ def _initialize_with_android_home(env):
     logger.debug('Using ANDROID_HOME from the environment.')
     env.android_home = android_home
     env.platform_tools = os.path.join(android_home, 'platform-tools')
-    os.environ['PATH'] = env.platform_tools + os.pathsep + os.environ['PATH']
+    os.environ['PATH'] = os.environ['PATH'] + os.pathsep + env.platform_tools
     _init_common(env)
     return env
 


### PR DESCRIPTION
devlib currently prepends platform-tools at the beginning of PATH.
This makes WA3 use a different adb (the one in platform-tools) than
the one I use everywhere else.  Because they are different, whenever
the "other" adb starts, it kills the sessions of the previous one.

Instead of prepending and using a different adb than the reset of the
system, append platform-tools to PATH, so that the adb used by WA3 and
the rest of the system is the same.