### PR TITLE
devlib/utils/ssh.py: Fix set terminal window size

### DIFF
--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -72,8 +72,14 @@ def ssh_get_shell(host, username, password=None, keyfile=None, port=None, timeou
                 raise TargetError(message.format(host))
             time.sleep(5)
 
+    conn.sendline('shopt -s checkwinsize')
+    conn.prompt()
     conn.setwinsize(500,200)
     conn.sendline('')
+    conn.prompt()
+    conn.sendline('stty rows 500')
+    conn.prompt()
+    conn.sendline('stty cols 200')
     conn.prompt()
     conn.setecho(False)
     return conn


### PR DESCRIPTION
Ensure that the terminal window size is set to 500x200, if not long
commands (prompt + command > 80 chars) will fail because the pexpect
search to match the command string in order to get the result and the
command is wrapped to first 80 chars.

In order to fix this scenario enables checkwinsize in the shell and use
stty to set the new terminal window size.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>