### PR TITLE
LinuxTarget: Ensure path is correctly quoted when listing directories

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -883,7 +883,7 @@ class LinuxTarget(Target):
             return filtered_result
 
     def list_directory(self, path, as_root=False):
-        contents = self.execute('ls -1 {}'.format(path), as_root=as_root)
+        contents = self.execute('ls -1 "{}"'.format(escape_double_quotes(path)), as_root=as_root)
         return [x.strip() for x in contents.split('\n') if x.strip()]
 
     def install(self, filepath, timeout=None, with_name=None):  # pylint: disable=W0221


### PR DESCRIPTION
Previously the path for listing a directory on the device was not quoted
causing it to fail on paths containing spaces. Now ensure the string is
quoted and any quotes contained in the string as escaped.