### PR TITLE
AndroidTarget: Ensure path is correctly quoted when listing directories

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1099,7 +1099,7 @@ class AndroidTarget(Target):
     def list_directory(self, path, as_root=False):
         if self.ls_command == '':
             self.__setup_list_directory()
-        contents = self.execute('{} {}'.format(self.ls_command, path), as_root=as_root)
+        contents = self.execute('{} "{}"'.format(self.ls_command, escape_double_quotes(path)), as_root=as_root)
         return [x.strip() for x in contents.split('\n') if x.strip()]
 
     def install(self, filepath, timeout=None, with_name=None):  # pylint: disable=W0221


### PR DESCRIPTION
Previously the path for listing a directory on the device was not quoted
causing it to fail on paths containing spaces. Now ensure the string is
quoted and any quotes contained in the string as escaped.