### PR TITLE
module/cpuidle: ensure get_states() returns a list

### DIFF
--- a/devlib/module/cpuidle.py
+++ b/devlib/module/cpuidle.py
@@ -132,7 +132,7 @@ class Cpuidle(Module):
     def get_states(self, cpu=0):
         if isinstance(cpu, int):
             cpu = 'cpu{}'.format(cpu)
-        return self._states.get(cpu)
+        return self._states.get(cpu, [])
 
     def get_state(self, state, cpu=0):
         if isinstance(state, int):


### PR DESCRIPTION
Ensure that cpuidle.get_states() always returns a list, even if no idle
states are available on the target.