### PR TITLE
[RFC] Add support for Python 3

### DIFF
--- a/devlib/derived/energy.py
+++ b/devlib/derived/energy.py
@@ -34,7 +34,7 @@ class DerivedEnergyMeasurements(DerivedMeasurements):
             if channel.site == 'timestamp':
                 use_timestamp = True
                 time_measurment = channel.measurement_type
-        for site, kinds in channel_map.iteritems():
+        for site, kinds in channel_map.items():
             if 'power' in kinds and not 'energy' in kinds:
                 should_calculate_energy.append(site)
 

--- a/devlib/derived/fps.py
+++ b/devlib/derived/fps.py
@@ -1,5 +1,4 @@
 from __future__ import division
-import csv
 import os
 import re
 
@@ -8,8 +7,11 @@ try:
 except ImportError:
     pd = None
 
+from past.builtins import basestring
+
 from devlib import DerivedMeasurements, DerivedMetric, MeasurementsCsv, InstrumentChannel
 from devlib.exception import HostError
+from devlib.utils.csvutil import csvwriter
 from devlib.utils.rendering import gfxinfo_get_last_dump, VSYNC_INTERVAL
 from devlib.utils.types import numeric
 
@@ -103,8 +105,7 @@ class DerivedGfxInfoStats(DerivedFpsStats):
             fps = 0
 
         csv_file = self._get_csv_file_name(measurements_csv.path)
-        with open(csv_file, 'wb') as wfh:
-            writer = csv.writer(wfh)
+        with csvwriter(csv_file) as writer:
             writer.writerow(['fps'])
             writer.writerows(per_frame_fps)
 

--- a/devlib/exception.py
+++ b/devlib/exception.py
@@ -15,7 +15,11 @@
 
 class DevlibError(Exception):
     """Base class for all Devlib exceptions."""
-    pass
+    @property
+    def message(self):
+        if self.args:
+            return self.args[0]
+        return str(self)
 
 
 class TargetError(DevlibError):
@@ -75,13 +79,13 @@ def get_traceback(exc=None):
     object, or for the current exception exc is not specified.
 
     """
-    import StringIO, traceback, sys
+    import io, traceback, sys
     if exc is None:
         exc = sys.exc_info()
     if not exc:
         return None
     tb = exc[2]
-    sio = StringIO.StringIO()
+    sio = io.BytesIO()
     traceback.print_tb(tb, file=sio)
     del tb  # needs to be done explicitly see: http://docs.python.org/2/library/sys.html#sys.exc_info
     return sio.getvalue()

--- a/devlib/instrument/arm_energy_probe.py
+++ b/devlib/instrument/arm_energy_probe.py
@@ -17,7 +17,6 @@
 # pylint: disable=W0613,E1101,access-member-before-definition,attribute-defined-outside-init
 from __future__ import division
 import os
-import csv
 import subprocess
 import signal
 import struct
@@ -28,6 +27,7 @@ import shutil
 
 from devlib.instrument import Instrument, CONTINUOUS, MeasurementsCsv
 from devlib.exception import HostError
+from devlib.utils.csvutil import csvreader, csvwriter
 from devlib.utils.misc import which
 
 from devlib.utils.parse_aep import AepParser
@@ -108,10 +108,8 @@ class ArmEnergyProbeInstrument(Instrument):
         active_channels = [c.label for c in self.active_channels]
         active_indexes = [all_channels.index(ac) for ac in active_channels]
 
-        with open(self.output_file, 'rb') as ifile:
-            reader = csv.reader(ifile, delimiter=' ')
-            with open(outfile, 'wb') as wfh:
-                writer = csv.writer(wfh)
+        with csvreader(self.output_file, delimiter=' ') as reader:
+            with csvwriter(outfile) as writer:
                 for row in reader:
                     if skip_header == 1:
                         writer.writerow(active_channels)

--- a/devlib/instrument/gem5power.py
+++ b/devlib/instrument/gem5power.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 from __future__ import division
-import csv
 import re
 
 from devlib.platform.gem5 import Gem5SimulationPlatform
 from devlib.instrument import Instrument, CONTINUOUS, MeasurementsCsv
 from devlib.exception import TargetError, HostError
+from devlib.utils.csvutil import csvwriter
 
 
 class Gem5PowerInstrument(Instrument):
@@ -66,8 +66,7 @@ class Gem5PowerInstrument(Instrument):
 
     def get_data(self, outfile):
         active_sites = [c.site for c in self.active_channels]
-        with open(outfile, 'wb') as wfh:
-            writer = csv.writer(wfh)
+        with csvwriter(outfile) as writer:
             writer.writerow([c.label for c in self.active_channels]) # headers
             sites_to_match = [self.site_mapping.get(s, s) for s in active_sites]
             for rec, rois in self.target.gem5stats.match_iter(sites_to_match,

--- a/devlib/instrument/netstats/__init__.py
+++ b/devlib/instrument/netstats/__init__.py
@@ -1,14 +1,15 @@
 import os
 import re
-import csv
 import tempfile
 from datetime import datetime
 from collections import defaultdict
-from itertools import izip_longest
+
+from future.moves.itertools import zip_longest
 
 from devlib.instrument import Instrument, MeasurementsCsv, CONTINUOUS
 from devlib.exception import TargetError, HostError
 from devlib.utils.android import ApkInfo
+from devlib.utils.csvutil import csvwriter
 
 
 THIS_DIR = os.path.dirname(__file__)
@@ -46,10 +47,9 @@ def netstats_to_measurements(netstats):
 def write_measurements_csv(measurements, filepath):
     headers = sorted(measurements.keys())
     columns = [measurements[h] for h in headers]
-    with open(filepath, 'wb') as wfh:
-        writer = csv.writer(wfh)
+    with csvwriter(filepath) as writer:
         writer.writerow(headers)
-        writer.writerows(izip_longest(*columns))
+        writer.writerows(zip_longest(*columns))
 
 
 class NetstatsInstrument(Instrument):

--- a/devlib/module/__init__.py
+++ b/devlib/module/__init__.py
@@ -15,6 +15,8 @@
 import logging
 from inspect import isclass
 
+from past.builtins import basestring
+
 from devlib.utils.misc import walk_modules
 from devlib.utils.types import identifier
 
@@ -75,7 +77,7 @@ class BootModule(Module):  # pylint: disable=R0921
         raise NotImplementedError()
 
     def update(self, **kwargs):
-        for name, value in kwargs.iteritems():
+        for name, value in kwargs.items():
             if not hasattr(self, name):
                 raise ValueError('Unknown parameter "{}" for {}'.format(name, self.name))
             self.logger.debug('Updating "{}" to "{}"'.format(name, value))
@@ -117,6 +119,6 @@ def register_module(mod):
 
 def __load_cache():
     for module in walk_modules('devlib.module'):
-        for obj in vars(module).itervalues():
+        for obj in vars(module).values():
             if isclass(obj) and issubclass(obj, Module) and obj.name:
                 register_module(obj)

--- a/devlib/module/android.py
+++ b/devlib/module/android.py
@@ -63,7 +63,7 @@ class FastbootFlashModule(FlashModule):
             image_bundle = expand_path(image_bundle)
             to_flash = self._bundle_to_images(image_bundle)
         to_flash = merge_dicts(to_flash, images or {}, should_normalize=False)
-        for partition, image_path in to_flash.iteritems():
+        for partition, image_path in to_flash.items():
             self.logger.debug('flashing {}'.format(partition))
             self._flash_image(self.target, partition, expand_path(image_path))
         fastboot_command('reboot')

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -325,7 +325,7 @@ class CGroup(object):
     def get_tasks(self):
         task_ids = self.target.read_value(self.tasks_file).split()
         logging.debug('Tasks: %s', task_ids)
-        return map(int, task_ids)
+        return list(map(int, task_ids))
 
     def add_task(self, tid):
         self.target.write_value(self.tasks_file, tid, verify=False)

--- a/devlib/module/cpufreq.py
+++ b/devlib/module/cpufreq.py
@@ -150,7 +150,7 @@ class CpufreqModule(Module):
         if governor is None:
             governor = self.get_governor(cpu)
         valid_tunables = self.list_governor_tunables(cpu)
-        for tunable, value in kwargs.iteritems():
+        for tunable, value in kwargs.items():
             if tunable in valid_tunables:
                 path = '/sys/devices/system/cpu/{}/cpufreq/{}/{}'.format(cpu, governor, tunable)
                 try:
@@ -176,7 +176,7 @@ class CpufreqModule(Module):
         try:
             cmd = 'cat /sys/devices/system/cpu/{}/cpufreq/scaling_available_frequencies'.format(cpu)
             output = self.target.execute(cmd)
-            available_frequencies = map(int, output.strip().split())  # pylint: disable=E1103
+            available_frequencies = list(map(int, output.strip().split()))  # pylint: disable=E1103
         except TargetError:
             # On some devices scaling_frequencies  is not generated.
             # http://adrynalyne-teachtofish.blogspot.co.uk/2011/11/how-to-enable-scalingavailablefrequenci.html
@@ -190,7 +190,7 @@ class CpufreqModule(Module):
                     return []
                 raise
 
-            available_frequencies = map(int, reversed([f for f, _ in zip(out_iter, out_iter)]))
+            available_frequencies = list(map(int, reversed([f for f, _ in zip(out_iter, out_iter)])))
         return available_frequencies
 
     def get_min_frequency(self, cpu):
@@ -460,7 +460,7 @@ class CpufreqModule(Module):
         """
         cpus = set(range(self.target.number_of_cpus))
         while cpus:
-            cpu = iter(cpus).next()
+            cpu = next(iter(cpus))
             domain = self.target.cpufreq.get_related_cpus(cpu)
             yield domain
             cpus = cpus.difference(domain)

--- a/devlib/module/cpuidle.py
+++ b/devlib/module/cpuidle.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 # pylint: disable=attribute-defined-outside-init
+from past.builtins import basestring
+
 from devlib.module import Module
 from devlib.utils.misc import memoized
 from devlib.utils.types import integer, boolean

--- a/devlib/module/gem5stats.py
+++ b/devlib/module/gem5stats.py
@@ -75,7 +75,7 @@ class Gem5StatsModule(Module):
             raise KeyError('ROI label {} already used'.format(label))
         if len(self.rois) >= GEM5STATS_ROI_NUMBER:
             raise RuntimeError('Too many ROIs reserved')
-        all_rois = set(xrange(GEM5STATS_ROI_NUMBER))
+        all_rois = set(range(GEM5STATS_ROI_NUMBER))
         used_rois = set([roi.number for roi in self.rois.values()])
         avail_rois = all_rois - used_rois
         self.rois[label] = Gem5ROI(list(avail_rois)[0], self.target)
@@ -223,7 +223,7 @@ class Gem5StatsModule(Module):
         '''
         with open(self._stats_file_path, 'r') as stats_file:
             # _goto_dump reach EOF and returns the total number of dumps + 1
-            return self._goto_dump(stats_file, sys.maxint)
+            return self._goto_dump(stats_file, sys.maxsize)
     
     def _goto_dump(self, stats_file, target_dump):
         if target_dump < 0:
@@ -243,7 +243,7 @@ class Gem5StatsModule(Module):
         dump_iterator = iter_statistics_dump(stats_file)
         while curr_dump < target_dump:
             try:
-                dump = dump_iterator.next()
+                dump = next(dump_iterator)
             except StopIteration:
                 break
             # End of passed dump is beginning og next one

--- a/devlib/module/gpufreq.py
+++ b/devlib/module/gpufreq.py
@@ -26,7 +26,7 @@ class GpufreqModule(Module):
     def __init__(self, target):
         super(GpufreqModule, self).__init__(target)
         frequencies_str = self.target.read_value("/sys/kernel/gpu/gpu_freq_table")
-        self.frequencies = map(int, frequencies_str.split(" "))
+        self.frequencies = list(map(int, frequencies_str.split(" ")))
         self.frequencies.sort()
         self.governors = self.target.read_value("/sys/kernel/gpu/gpu_available_governor").split(" ")
 

--- a/devlib/module/hwmon.py
+++ b/devlib/module/hwmon.py
@@ -75,8 +75,8 @@ class HwmonDevice(object):
     @property
     def sensors(self):
         all_sensors = []
-        for sensors_of_kind in self._sensors.itervalues():
-            all_sensors.extend(sensors_of_kind.values())
+        for sensors_of_kind in self._sensors.values():
+            all_sensors.extend(list(sensors_of_kind.values()))
         return all_sensors
 
     def __init__(self, target, path, name, fields):
@@ -100,7 +100,7 @@ class HwmonDevice(object):
 
     def get(self, kind, number=None):
         if number is None:
-            return [s for _, s in sorted(self._sensors[kind].iteritems(),
+            return [s for _, s in sorted(self._sensors[kind].items(),
                                          key=lambda x: x[0])]
         else:
             return self._sensors[kind].get(number)
@@ -139,7 +139,7 @@ class HwmonModule(Module):
 
     def scan(self):
         values_tree = self.target.read_tree_values(self.root, depth=3)
-        for entry_id, fields in values_tree.iteritems():
+        for entry_id, fields in values_tree.items():
             path = self.target.path.join(self.root, entry_id)
             name = fields.pop('name', None)
             if name is None:

--- a/devlib/module/thermal.py
+++ b/devlib/module/thermal.py
@@ -100,5 +100,5 @@ class ThermalModule(Module):
 
     def disable_all_zones(self):
         """Disables all the thermal zones in the target"""
-        for zone in self.zones.itervalues():
+        for zone in self.zones.values():
             zone.set_enabled(False)

--- a/devlib/module/vexpress.py
+++ b/devlib/module/vexpress.py
@@ -251,7 +251,7 @@ class VexpressUBoot(VexpressBootModule):
         menu = UbootMenu(tty)
         self.logger.debug('Waiting for U-Boot prompt...')
         menu.open(timeout=120)
-        for var, value in self.env.iteritems():
+        for var, value in self.env.items():
             menu.setenv(var, value)
         menu.boot()
 
@@ -338,7 +338,7 @@ class VersatileExpressFlashModule(FlashModule):
             if images:
                 self._overlay_images(images)
             os.system('sync')
-        except (IOError, OSError), e:
+        except (IOError, OSError) as e:
             msg = 'Could not deploy images to {}; got: {}'
             raise TargetError(msg.format(self.vemsd_mount, e))
         self.target.boot()
@@ -352,7 +352,7 @@ class VersatileExpressFlashModule(FlashModule):
             tar.extractall(self.vemsd_mount)
 
     def _overlay_images(self, images):
-        for dest, src in images.iteritems():
+        for dest, src in images.items():
             dest = os.path.join(self.vemsd_mount, dest)
             self.logger.debug('Copying {} to {}'.format(src, dest))
             shutil.copy(src, dest)
@@ -379,7 +379,7 @@ def wait_for_vemsd(vemsd_mount, tty, mcc_prompt=DEFAULT_MCC_PROMPT, short_delay=
     path = os.path.join(vemsd_mount, 'config.txt')
     if os.path.exists(path):
         return
-    for _ in xrange(attempts):
+    for _ in range(attempts):
         tty.sendline('')  # clear any garbage
         tty.expect(mcc_prompt, timeout=short_delay)
         tty.sendline('usb_on')

--- a/devlib/platform/gem5.py
+++ b/devlib/platform/gem5.py
@@ -63,13 +63,12 @@ class Gem5SimulationPlatform(Platform):
 
         # Find the first one that does not exist. Ensures that we do not re-use
         # the directory used by someone else.
-        for i in xrange(sys.maxint):
+        i = 0
+        directory = os.path.join(self.gem5_interact_dir, "wa_{}".format(i))
+        while os.path.exists(directory):
+            i += 1
             directory = os.path.join(self.gem5_interact_dir, "wa_{}".format(i))
-            try:
-                os.stat(directory)
-                continue
-            except OSError:
-                break
+
         self.gem5_interact_dir = directory
         self.logger.debug("Using {} as the temporary directory."
                           .format(self.gem5_interact_dir))

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -19,6 +19,7 @@ import json
 import time
 import re
 import subprocess
+import sys
 
 from devlib.trace import TraceCollector
 from devlib.host import PACKAGE_BIN_DIRECTORY
@@ -121,7 +122,7 @@ class FtraceCollector(TraceCollector):
                 _event = '*' + event
             event_re = re.compile(_event.replace('*', '.*'))
             # Select events matching the required ones
-            if len(filter(event_re.match, available_events)) == 0:
+            if len(list(filter(event_re.match, available_events))) == 0:
                 message = 'Event [{}] not available for tracing'.format(event)
                 if strict:
                     raise TargetError(message)
@@ -276,6 +277,8 @@ class FtraceCollector(TraceCollector):
             self.logger.debug(command)
             process = subprocess.Popen(command, stderr=subprocess.PIPE, shell=True)
             _, error = process.communicate()
+            if sys.version_info[0] == 3:
+                error = error.decode(sys.stdout.encoding)
             if process.returncode:
                 raise TargetError('trace-cmd returned non-zero exit code {}'.format(process.returncode))
             if error:

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -27,7 +27,8 @@ import logging
 import re
 import threading
 import tempfile
-import Queue
+import queue
+import sys
 from collections import defaultdict
 
 from devlib.exception import TargetError, HostError, DevlibError
@@ -88,7 +89,7 @@ class AndroidProperties(object):
         self._properties = dict(re.findall(r'\[(.*?)\]:\s+\[(.*?)\]', text))
 
     def iteritems(self):
-        return self._properties.iteritems()
+        return iter(self._properties.items())
 
     def __iter__(self):
         return iter(self._properties)
@@ -140,6 +141,8 @@ class ApkInfo(object):
         logger.debug(' '.join(command))
         try:
             output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+            if sys.version_info[0] == 3:
+                output = output.decode(sys.stdout.encoding)
         except subprocess.CalledProcessError as e:
             raise HostError('Error parsing APK file {}. `aapt` says:\n{}'
                             .format(apk_path, e.output))
@@ -160,7 +163,7 @@ class ApkInfo(object):
                 mapped_abis = []
                 for apk_abi in apk_abis:
                     found = False
-                    for abi, architectures in ABI_MAP.iteritems():
+                    for abi, architectures in ABI_MAP.items():
                         if apk_abi in architectures:
                             mapped_abis.append(abi)
                             found = True

--- a/devlib/utils/csvutil.py
+++ b/devlib/utils/csvutil.py
@@ -1,0 +1,85 @@
+'''
+Due to the change in the nature of "binary mode" when opening files in
+Python 3, the way files need to be opened for ``csv.reader`` and ``csv.writer``
+is different from Python 2.
+
+The functions in this module are intended to hide these differences allowing
+the rest of the code to create csv readers/writers without worrying about which
+Python version it is running under.
+
+First up are ``csvwriter`` and ``csvreader`` context mangers that handle the
+opening and closing of the underlying file. These are intended to replace the
+most common usage pattern
+
+.. code-block:: python
+
+    with open(filepath, 'wb') as wfh:  # or open(filepath, 'w', newline='') in Python 3
+        writer = csv.writer(wfh)
+        writer.writerows(data)
+
+
+with
+
+.. code-block:: python
+
+    with csvwriter(filepath) as writer:
+        writer.writerows(data)
+
+
+``csvreader`` works in an analogous way. ``csvreader`` and ``writer`` can take
+additional arguments which will be passed directly to the
+``csv.reader``/``csv.writer`` calls.
+
+In some cases, it is desirable not to use a context manager (e.g. if the
+reader/writer is intended to be returned from the function that creates it. For
+such cases, alternative functions, ``create_reader`` and ``create_writer``,
+exit. These return a two-tuple, with the created reader/writer as the first
+element, and the corresponding ``FileObject`` as the second. It is the
+responsibility of the calling code to ensure that the file is closed properly.
+
+'''
+import csv
+import sys
+from contextlib import contextmanager
+
+
+@contextmanager
+def csvwriter(filepath, *args, **kwargs):
+    if sys.version_info[0] == 3:
+        wfh = open(filepath, 'w', newline='')
+    else:
+        wfh = open(filepath, 'wb')
+
+    try:
+        yield csv.writer(wfh, *args, **kwargs)
+    finally:
+        wfh.close()
+
+
+@contextmanager
+def csvreader(filepath, *args, **kwargs):
+    if sys.version_info[0] == 3:
+        fh = open(filepath, 'r', newline='')
+    else:
+        fh = open(filepath, 'rb')
+
+    try:
+        yield csv.reader(fh, *args, **kwargs)
+    finally:
+        fh.close()
+
+
+def create_writer(filepath, *args, **kwargs):
+    if sys.version_info[0] == 3:
+        wfh = open(filepath, 'w', newline='')
+    else:
+        wfh = open(filepath, 'wb')
+    return csv.writer(wfh, *args, **kwargs), wfh
+
+
+def create_reader(filepath, *args, **kwargs):
+    if sys.version_info[0] == 3:
+        fh = open(filepath, 'r', newline='')
+    else:
+        fh = open(filepath, 'rb')
+    return csv.reader(fh, *args, **kwargs), fh

--- a/devlib/utils/gem5.py
+++ b/devlib/utils/gem5.py
@@ -45,7 +45,7 @@ def iter_statistics_dump(stats_file):
                 k = res.group("key")
                 vtext = res.group("value")
                 try:
-                    v = map(numeric, vtext.split())
+                    v = list(map(numeric, vtext.split()))
                     cur_dump[k] = v[0] if len(v)==1 else set(v)
                 except ValueError:
                     msg = 'Found non-numeric entry in gem5 stats ({}: {})'

--- a/devlib/utils/parse_aep.py
+++ b/devlib/utils/parse_aep.py
@@ -67,7 +67,7 @@ class AepParser(object):
         virtual = {}
 
         # Create an entry for each virtual parent
-        for supply in topo.iterkeys():
+        for supply in topo.keys():
             index = topo[supply]['index']
             # Don't care of hidden columns
             if hide[index]:
@@ -85,11 +85,11 @@ class AepParser(object):
 
         # Remove parent with 1 child as they don't give more information than their
         # child
-        for supply in virtual.keys():
+        for supply in list(virtual.keys()):
             if len(virtual[supply]) == 1:
                 del virtual[supply];
 
-        for supply in virtual.keys():
+        for supply in list(virtual.keys()):
             # Add label, hide and duplicate columns for virtual domains
             hide.append(0)
             duplicate.append(1)
@@ -166,9 +166,9 @@ class AepParser(object):
     @staticmethod
     def add_virtual_data(data, virtual):
         # write virtual domain
-        for parent in virtual.iterkeys():
+        for parent in virtual.keys():
             power = 0
-            for child in virtual[parent].values():
+            for child in list(virtual[parent].values()):
                 try:
                     power += data[child]
                 except IndexError:
@@ -440,7 +440,7 @@ class AepParser(object):
 
 
         # Create an entry for each virtual parent
-        for supply in topo.iterkeys():
+        for supply in topo.keys():
             # Parent is in the topology
             parent = topo[supply]['parent']
             if parent in topo:
@@ -454,15 +454,15 @@ class AepParser(object):
 
         # Remove parent with 1 child as they don't give more information than their
         # child
-        for supply in virtual.keys():
+        for supply in list(virtual.keys()):
             if len(virtual[supply]) == 1:
                 del virtual[supply];
 
         topo_list = ['']*(1+len(topo)+len(virtual))
         topo_list[0] = 'time'
-        for chnl in topo.iterkeys():
+        for chnl in topo.keys():
             topo_list[topo[chnl]['index']] = chnl
-        for chnl in virtual.iterkeys():
+        for chnl in virtual.keys():
             index +=1
             topo_list[index] = chnl
 
@@ -495,7 +495,7 @@ if __name__ == '__main__':
     try:
         opts, args = getopt.getopt(sys.argv[1:], "i:vo:s:l:t:")
     except getopt.GetoptError as err:
-        print str(err) # will print something like "option -a not recognized"
+        print(str(err)) # will print something like "option -a not recognized"
         sys.exit(2)
 
     for o, a in opts:
@@ -513,7 +513,7 @@ if __name__ == '__main__':
         if o == "-t":
             topofile = a
             parser = AepParser()
-            print parser.topology_from_config(topofile)
+            print(parser.topology_from_config(topofile))
             exit(0)
 
     parser = AepParser()

--- a/devlib/utils/types.py
+++ b/devlib/utils/types.py
@@ -26,6 +26,9 @@ is not the best language to use for configuration.
 
 """
 import math
+from functools import total_ordering
+
+from past.builtins import basestring
 
 from devlib.utils.misc import isiterable, to_identifier, ranges_to_list, list_to_mask
 
@@ -88,6 +91,7 @@ def numeric(value):
     return fvalue
 
 
+@total_ordering
 class caseless_string(str):
     """
     Just like built-in Python string except case-insensitive on comparisons. However, the
@@ -100,13 +104,13 @@ class caseless_string(str):
             other = other.lower()
         return self.lower() == other
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __cmp__(self, other):
-        if isinstance(basestring, other):
+    def __lt__(self, other):
+        if isinstance(other, basestring):
             other = other.lower()
-        return cmp(self.lower(), other)
+        return self.lower() < other
+
+    def __hash__(self):
+        return hash(self.lower())
 
     def format(self, *args, **kwargs):
         return caseless_string(super(caseless_string, self).format(*args, **kwargs))

--- a/devlib/utils/uefi.py
+++ b/devlib/utils/uefi.py
@@ -19,6 +19,8 @@ import time
 import logging
 from copy import copy
 
+from past.builtins import basestring
+
 from devlib.utils.serial_port import write_characters, TIMEOUT
 from devlib.utils.types import boolean
 
@@ -193,14 +195,14 @@ class UefiMenu(object):
         is not in the current menu, ``LookupError`` will be raised."""
         if not self.prompt:
             self.read_menu(timeout)
-        return self.options.items()
+        return list(self.options.items())
 
     def get_option_index(self, text, timeout=default_timeout):
         """Returns the menu index of the specified option text (uses regex matching). If the option
         is not in the current menu, ``LookupError`` will be raised."""
         if not self.prompt:
             self.read_menu(timeout)
-        for k, v in self.options.iteritems():
+        for k, v in self.options.items():
             if re.search(text, v):
                 return k
         raise LookupError(text)

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ params = dict(
         'pexpect>=3.3',  # Send/recieve to/from device
         'pyserial',  # Serial port interface
         'wrapt',  # Basic for construction of decorator functions
+        'future', # Python 2-3 compatibility
     ],
     extras_require={
         'daq': ['daqpower'],
@@ -85,7 +86,7 @@ params = dict(
     ],
 )
 
-all_extras = list(chain(params['extras_require'].itervalues()))
+all_extras = list(chain(iter(params['extras_require'].values())))
 params['extras_require']['full'] = all_extras
 
 setup(**params)


### PR DESCRIPTION
Add support for running on Python 3 while maintaining Python 2
compatibility.

NOTE: this introduces a new dependency on the `future` package (which provides 2-3 interop)

This has been tested with WA Python 3 port (which exercises a large portion of
the devlib API) with Android and Linux targets, running on both 2.7 and 3.6 Python versions.