### PR TITLE
module/cpufreq: include policy0 in probe path

### DIFF
--- a/devlib/module/cpufreq.py
+++ b/devlib/module/cpufreq.py
@@ -37,7 +37,7 @@ class CpufreqModule(Module):
                 return True
 
         # Generic CPUFreq support (single policy)
-        path = '/sys/devices/system/cpu/cpufreq'
+        path = '/sys/devices/system/cpu/cpufreq/policy0'
         if target.file_exists(path):
             return True
 


### PR DESCRIPTION
Check /sys/devices/system/cpu/cpufreq/policy0 rather than its parent
during the probe. This is to handle the edge case where cpufreq has
been enabled in the kernel, but no frequency domains have been defined
(in which case, the module should not install).