### PR TITLE
Add Juno Shell Prompt Regex

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -29,6 +29,9 @@ ANDROID_SCREEN_RESOLUTION_REGEX = re.compile(r'mUnrestrictedScreen=\(\d+,\d+\)'
                                              r'\s+(?P<width>\d+)x(?P<height>\d+)')
 DEFAULT_SHELL_PROMPT = re.compile(r'^.*(shell|root|juno)@?.*:[/~]\S* *[#$] ',
                                   re.MULTILINE)
+JUNO_SHELL_PROMPT = re.compile(r'^.*(juno|shell|root)@?.*:/\S* [#$] ',
+                                  re.MULTILINE)
+
 KVERSION_REGEX =re.compile(
     r'(?P<version>\d+)(\.(?P<major>\d+)(\.(?P<minor>\d+)(-rc(?P<rc>\d+))?)?)?(.*-g(?P<sha1>[0-9a-fA-F]{7,}))?'
 )


### PR DESCRIPTION
Also checks for 'juno' in addition to 'root' and 'shell'.
Concurrent support added for parsing target params in the platform tuple
in WA which makes use of this.