### PR TITLE
utils/android: Try to ping adb devices regardless of connection type

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -314,18 +314,15 @@ def adb_get_device(timeout=None, adb_server=None):
 
 def adb_connect(device, timeout=None, attempts=MAX_ATTEMPTS):
     _check_env()
-    # Connect is required only for ADB-over-IP
-    if "." not in device:
-        logger.debug('Device connected via USB, connect not required')
-        return
     tries = 0
     output = None
     while tries <= attempts:
         tries += 1
         if device:
-            command = 'adb connect {}'.format(device)
-            logger.debug(command)
-            output, _ = check_output(command, shell=True, timeout=timeout)
+            if "." in device: # Connect is required only for ADB-over-IP
+                command = 'adb connect {}'.format(device)
+                logger.debug(command)
+                output, _ = check_output(command, shell=True, timeout=timeout)
         if _ping(device):
             break
         time.sleep(10)


### PR DESCRIPTION
Previously if a device was connected over usb then the adb_connect
method would assume the device was already connected. This can cause
issues when rebooting and the device is not ready by the time devlib
attempts to reconnect to it causing the next command to fail. Now still
only execute the 'connect' command when the device is connected over the
network, however always trying pinging the device to see if it is
connected before returning.