### PR TITLE
Fix Python3 Byte Handling

### DIFF
--- a/devlib/platform/arm.py
+++ b/devlib/platform/arm.py
@@ -14,6 +14,7 @@
 #
 from __future__ import division
 import os
+import sys
 import tempfile
 import time
 import pexpect

--- a/devlib/platform/arm.py
+++ b/devlib/platform/arm.py
@@ -88,6 +88,9 @@ class VersatileExpressPlatform(Platform):
     def _init_android_target(self, target):
         if target.connection_settings.get('device') is None:
             addr = self._get_target_ip_address(target)
+            if sys.version_info[0] == 3:
+                # Convert bytes to string for Python3 compatibility
+                addr = addr.decode("utf-8")
             target.connection_settings['device'] = addr + ':5555'
 
     def _init_linux_target(self, target):

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -179,8 +179,9 @@ def check_output(command, timeout=None, ignore=None, inputtext=None, **kwargs):
     try:
         output, error = process.communicate(inputtext)
         if sys.version_info[0] == 3:
-            output = output.decode(sys.stdout.encoding)
-            error =  error.decode(sys.stderr.encoding)
+            # Currently errors=replace is needed as 0x8c throws an error
+            output = output.decode(sys.stdout.encoding, "replace")
+            error =  error.decode(sys.stderr.encoding, "replace")
     finally:
         if timeout:
             timer.cancel()


### PR DESCRIPTION
Convert bytes to strings (utf-8 encoding) to make compatible with
Python3 in arm.py
Drop problematic characters when decoding stdout and stderr in misc.py
by setting errors='replace' in the string decode method.