### PR TITLE
trace/serial_trace: Flush data to file before copying

### DIFF
--- a/devlib/trace/serial_trace.py
+++ b/devlib/trace/serial_trace.py
@@ -69,6 +69,8 @@ class SerialTraceCollector(TraceCollector):
         if self._collecting:
             raise RuntimeError("get_trace was called whilst collecting")
 
+        self._tmpfile.flush()
+
         shutil.copy(self._tmpfile.name, outfile)
 
         self._tmpfile.close()


### PR DESCRIPTION
We add a missing flush which esures that all data has been synced to
the temporary file before we copy it. Prior to this commit, we would
sometimes miss the last few lines of the trace.