### PR TITLE
utils/types: implement __ne__ for caseless_string

### DIFF
--- a/devlib/utils/types.py
+++ b/devlib/utils/types.py
@@ -106,6 +106,11 @@ class caseless_string(str):
             other = other.lower()
         return self.lower() == other
 
+    def __ne__(self, other):
+        if isinstance(other, basestring):
+            other = other.lower()
+        return self.lower() != other
+
     def __lt__(self, other):
         if isinstance(other, basestring):
             other = other.lower()


### PR DESCRIPTION
This should have been handled by the @total_ordering decorator, but
isn't due to

	https://bugs.python.org/issue25732

(briefly, total_ordering is back-ported from Python 3, where the base
object provides the default implementation of __ne__ based on __eq__, so
total_ordering did not override it; this, however does not happen in
Python 2).