### PR TITLE
Classify exceptions

### DIFF
--- a/devlib/__init__.py
+++ b/devlib/__init__.py
@@ -15,7 +15,7 @@
 
 from devlib.target import Target, LinuxTarget, AndroidTarget, LocalLinuxTarget, ChromeOsTarget
 from devlib.host import PACKAGE_BIN_DIRECTORY
-from devlib.exception import DevlibError, TargetError, HostError, TargetNotRespondingError
+from devlib.exception import DevlibError, DevlibTransientError, DevlibStableError, TargetError, TargetTransientError, TargetStableError, TargetNotRespondingError, HostError
 
 from devlib.module import Module, HardRestModule, BootModule, FlashModule
 from devlib.module import get_module, register_module

--- a/devlib/exception.py
+++ b/devlib/exception.py
@@ -22,12 +22,43 @@ class DevlibError(Exception):
         return str(self)
 
 
+class DevlibStableError(DevlibError):
+    """Non transient target errors, that are not subject to random variations
+    in the environment and can be reliably linked to for example a missing
+    feature on a target."""
+    pass
+
+
+class DevlibTransientError(DevlibError):
+    """Exceptions inheriting from ``DevlibTransientError`` represent random
+    transient events that are usually related to issues in the environment, as
+    opposed to programming errors, for example network failures or
+    timeout-related exceptions. When the error could come from
+    indistinguishable transient or non-transient issue, it can generally be
+    assumed that the configuration is correct and therefore, a transient
+    exception is raised."""
+    pass
+
+
 class TargetError(DevlibError):
     """An error has occured on the target"""
     pass
 
 
-class TargetNotRespondingError(DevlibError):
+class TargetTransientError(TargetError, DevlibTransientError):
+    """Transient target errors that can happen randomly when everything is
+    properly configured."""
+    pass
+
+
+class TargetStableError(TargetError, DevlibStableError):
+    """Non-transient target errors that can be linked to a programming error or
+    a configuration issue, and is not influenced by non-controllable parameters
+    such as network issues."""
+    pass
+
+
+class TargetNotRespondingError(TargetTransientError):
     """The target is unresponsive."""
     pass
 
@@ -38,7 +69,7 @@ class HostError(DevlibError):
 
 
 # pylint: disable=redefined-builtin
-class TimeoutError(DevlibError):
+class TimeoutError(DevlibTransientError):
     """Raised when a subprocess command times out. This is basically a ``DevlibError``-derived version
     of ``subprocess.CalledProcessError``, the thinking being that while a timeout could be due to
     programming error (e.g. not setting long enough timers), it is often due to some failure in the

--- a/devlib/instrument/gem5power.py
+++ b/devlib/instrument/gem5power.py
@@ -16,7 +16,7 @@ from __future__ import division
 
 from devlib.platform.gem5 import Gem5SimulationPlatform
 from devlib.instrument import Instrument, CONTINUOUS, MeasurementsCsv
-from devlib.exception import TargetError
+from devlib.exception import TargetStableError
 from devlib.utils.csvutil import csvwriter
 
 
@@ -36,9 +36,9 @@ class Gem5PowerInstrument(Instrument):
             system.cluster0.cores0.power_model.static_power
         '''
         if not isinstance(target.platform, Gem5SimulationPlatform):
-            raise TargetError('Gem5PowerInstrument requires a gem5 platform')
+            raise TargetStableError('Gem5PowerInstrument requires a gem5 platform')
         if not target.has('gem5stats'):
-            raise TargetError('Gem5StatsModule is not loaded')
+            raise TargetStableError('Gem5StatsModule is not loaded')
         super(Gem5PowerInstrument, self).__init__(target)
 
         # power_sites is assumed to be a list later

--- a/devlib/instrument/hwmon.py
+++ b/devlib/instrument/hwmon.py
@@ -16,7 +16,7 @@ from __future__ import division
 import re
 
 from devlib.instrument import Instrument, Measurement, INSTANTANEOUS
-from devlib.exception import TargetError
+from devlib.exception import TargetStableError
 
 
 class HwmonInstrument(Instrument):
@@ -35,7 +35,7 @@ class HwmonInstrument(Instrument):
 
     def __init__(self, target):
         if not hasattr(target, 'hwmon'):
-            raise TargetError('Target does not support HWMON')
+            raise TargetStableError('Target does not support HWMON')
         super(HwmonInstrument, self).__init__(target)
 
         self.logger.debug('Discovering available HWMON sensors...')

--- a/devlib/instrument/netstats/__init__.py
+++ b/devlib/instrument/netstats/__init__.py
@@ -84,7 +84,7 @@ class NetstatsInstrument(Instrument):
 
         """
         if target.os != 'android':
-            raise TargetStableError('netstats insturment only supports Android targets')
+            raise TargetStableError('netstats instrument only supports Android targets')
         if apk is None:
             apk = os.path.join(THIS_DIR, 'netstats.apk')
         if not os.path.isfile(apk):

--- a/devlib/instrument/netstats/__init__.py
+++ b/devlib/instrument/netstats/__init__.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 from future.moves.itertools import zip_longest
 
 from devlib.instrument import Instrument, MeasurementsCsv, CONTINUOUS
-from devlib.exception import TargetError, HostError
+from devlib.exception import TargetStableError, HostError
 from devlib.utils.android import ApkInfo
 from devlib.utils.csvutil import csvwriter
 
@@ -84,7 +84,7 @@ class NetstatsInstrument(Instrument):
 
         """
         if target.os != 'android':
-            raise TargetError('netstats insturment only supports Android targets')
+            raise TargetStableError('netstats insturment only supports Android targets')
         if apk is None:
             apk = os.path.join(THIS_DIR, 'netstats.apk')
         if not os.path.isfile(apk):

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -18,7 +18,7 @@ import re
 from collections import namedtuple
 
 from devlib.module import Module
-from devlib.exception import TargetError
+from devlib.exception import TargetStableError
 from devlib.utils.misc import list_to_ranges, isiterable
 from devlib.utils.types import boolean
 
@@ -281,7 +281,7 @@ class CGroup(object):
             self.target.execute('[ -d {0} ]'\
                 .format(self.directory), as_root=True)
             return True
-        except TargetError:
+        except TargetStableError:
             return False
 
     def get(self):
@@ -319,7 +319,7 @@ class CGroup(object):
             # Set the attribute value
             try:
                 self.target.write_value(path, attrs[idx])
-            except TargetError:
+            except TargetStableError:
                 # Check if the error is due to a non-existing attribute
                 attrs = self.get()
                 if idx not in attrs:
@@ -389,9 +389,9 @@ class CgroupsModule(Module):
             controller = Controller(ss.name, hid, hierarchy[hid])
             try:
                 controller.mount(self.target, self.cgroup_root)
-            except TargetError:
+            except TargetStableError:
                 message = 'Failed to mount "{}" controller'
-                raise TargetError(message.format(controller.kind))
+                raise TargetStableError(message.format(controller.kind))
             self.logger.info('  %-12s : %s', controller.kind,
                              controller.mount_point)
             self.controllers[ss.name] = controller

--- a/devlib/module/devfreq.py
+++ b/devlib/module/devfreq.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 from devlib.module import Module
-from devlib.exception import TargetError
+from devlib.exception import TargetStableError
 from devlib.utils.misc import memoized
 
 class DevfreqModule(Module):
@@ -64,13 +64,13 @@ class DevfreqModule(Module):
         Additional keyword arguments can be used to specify governor tunables for
         governors that support them.
 
-        :raises: TargetError if governor is not supported by the device, or if,
+        :raises: TargetStableError if governor is not supported by the device, or if,
                  for some reason, the governor could not be set.
 
         """
         supported = self.list_governors(device)
         if governor not in supported:
-            raise TargetError('Governor {} not supported for device {}'.format(governor, device))
+            raise TargetStableError('Governor {} not supported for device {}'.format(governor, device))
         sysfile = '/sys/class/devfreq/{}/governor'.format(device)
         self.target.write_value(sysfile, governor)
 
@@ -94,7 +94,7 @@ class DevfreqModule(Module):
         will try to read the minimum frequency and the following exception will
         be raised ::
 
-        :raises: TargetError if for some reason the frequency could not be read.
+        :raises: TargetStableError if for some reason the frequency could not be read.
 
         """
         sysfile = '/sys/class/devfreq/{}/min_freq'.format(device)
@@ -112,7 +112,7 @@ class DevfreqModule(Module):
 
         on the device.
 
-        :raises: TargetError if the frequency is not supported by the device, or if, for
+        :raises: TargetStableError if the frequency is not supported by the device, or if, for
                  some reason, frequency could not be set.
         :raises: ValueError if ``frequency`` is not an integer.
 
@@ -121,7 +121,7 @@ class DevfreqModule(Module):
         try:
             value = int(frequency)
             if exact and available_frequencies and value not in available_frequencies:
-                raise TargetError('Can\'t set {} frequency to {}\nmust be in {}'.format(device,
+                raise TargetStableError('Can\'t set {} frequency to {}\nmust be in {}'.format(device,
                                                                                         value,
                                                                                         available_frequencies))
             sysfile = '/sys/class/devfreq/{}/min_freq'.format(device)
@@ -137,7 +137,7 @@ class DevfreqModule(Module):
         will try to read the current frequency and the following exception will
         be raised ::
 
-        :raises: TargetError if for some reason the frequency could not be read.
+        :raises: TargetStableError if for some reason the frequency could not be read.
 
         """
         sysfile = '/sys/class/devfreq/{}/cur_freq'.format(device)
@@ -151,7 +151,7 @@ class DevfreqModule(Module):
         try to read the maximum frequency and the following exception will be
         raised ::
 
-        :raises: TargetError if for some reason the frequency could not be read.
+        :raises: TargetStableError if for some reason the frequency could not be read.
         """
         sysfile = '/sys/class/devfreq/{}/max_freq'.format(device)
         return self.target.read_int(sysfile)
@@ -168,7 +168,7 @@ class DevfreqModule(Module):
 
         on the device.
 
-        :raises: TargetError if the frequency is not supported by the device, or
+        :raises: TargetStableError if the frequency is not supported by the device, or
                  if, for some reason, frequency could not be set.
         :raises: ValueError if ``frequency`` is not an integer.
 
@@ -180,7 +180,7 @@ class DevfreqModule(Module):
             raise ValueError('Frequency must be an integer; got: "{}"'.format(frequency))
 
         if exact and value not in available_frequencies:
-            raise TargetError('Can\'t set {} frequency to {}\nmust be in {}'.format(device,
+            raise TargetStableError('Can\'t set {} frequency to {}\nmust be in {}'.format(device,
                                                                                     value,
                                                                                     available_frequencies))
         sysfile = '/sys/class/devfreq/{}/max_freq'.format(device)
@@ -202,13 +202,13 @@ class DevfreqModule(Module):
         try:
             return self.target._execute_util(  # pylint: disable=protected-access
                 'devfreq_set_all_governors {}'.format(governor), as_root=True)
-        except TargetError as e:
+        except TargetStableError as e:
             if ("echo: I/O error" in str(e) or
                 "write error: Invalid argument" in str(e)):
 
                 devs_unsupported = [d for d in self.target.list_devices()
                                     if governor not in self.list_governors(d)]
-                raise TargetError("Governor {} unsupported for devices {}".format(
+                raise TargetStableError("Governor {} unsupported for devices {}".format(
                     governor, devs_unsupported))
             else:
                 raise

--- a/devlib/module/gem5stats.py
+++ b/devlib/module/gem5stats.py
@@ -17,7 +17,7 @@ import sys
 import os.path
 from collections import defaultdict
 
-from devlib.exception import TargetError, HostError
+from devlib.exception import TargetStableError, HostError
 from devlib.module import Module
 from devlib.platform.gem5 import Gem5SimulationPlatform
 from devlib.utils.gem5 import iter_statistics_dump, GEM5STATS_ROI_NUMBER
@@ -87,13 +87,13 @@ class Gem5StatsModule(Module):
         if label not in self.rois:
             raise KeyError('Incorrect ROI label: {}'.format(label))
         if not self.rois[label].start():
-            raise TargetError('ROI {} was already running'.format(label))
+            raise TargetStableError('ROI {} was already running'.format(label))
 
     def roi_end(self, label):
         if label not in self.rois:
             raise KeyError('Incorrect ROI label: {}'.format(label))
         if not self.rois[label].stop():
-            raise TargetError('ROI {} was not running'.format(label))
+            raise TargetStableError('ROI {} was not running'.format(label))
 
     def start_periodic_dump(self, delay_ns=0, period_ns=10000000):
         # Default period is 10ms because it's roughly what's needed to have

--- a/devlib/module/gpufreq.py
+++ b/devlib/module/gpufreq.py
@@ -29,7 +29,7 @@
 
 import re
 from devlib.module import Module
-from devlib.exception import TargetError
+from devlib.exception import TargetStableError
 from devlib.utils.misc import memoized
 
 class GpufreqModule(Module):
@@ -56,7 +56,7 @@ class GpufreqModule(Module):
 
     def set_governor(self, governor):
         if governor not in self.governors:
-            raise TargetError('Governor {} not supported for gpu'.format(governor))
+            raise TargetStableError('Governor {} not supported for gpu'.format(governor))
         self.target.write_value("/sys/kernel/gpu/gpu_governor", governor)
 
     def get_frequencies(self):
@@ -73,7 +73,7 @@ class GpufreqModule(Module):
         try to read the current frequency and the following exception will be
         raised ::
 
-        :raises: TargetError if for some reason the frequency could not be read.
+        :raises: TargetStableError if for some reason the frequency could not be read.
 
         """
         return int(self.target.read_value("/sys/kernel/gpu/gpu_clock"))

--- a/devlib/module/hwmon.py
+++ b/devlib/module/hwmon.py
@@ -15,7 +15,7 @@
 import re
 from collections import defaultdict
 
-from devlib import TargetError
+from devlib import TargetStableError
 from devlib.module import Module
 from devlib.utils.types import integer
 
@@ -118,7 +118,7 @@ class HwmonModule(Module):
     def probe(target):
         try:
             target.list_directory(HWMON_ROOT, as_root=target.is_rooted)
-        except TargetError:
+        except TargetStableError:
             # Doesn't exist or no permissions
             return False
         return True

--- a/devlib/platform/arm.py
+++ b/devlib/platform/arm.py
@@ -19,7 +19,7 @@ import tempfile
 import time
 import pexpect
 
-from devlib.exception import TargetError, HostError
+from devlib.exception import TargetStableError, HostError
 from devlib.host import PACKAGE_BIN_DIRECTORY
 from devlib.instrument import (Instrument, InstrumentChannel, MeasurementsCsv,
                                Measurement, CONTINUOUS, INSTANTANEOUS)
@@ -123,7 +123,7 @@ class VersatileExpressPlatform(Platform):
                     except pexpect.TIMEOUT:
                         pass  # We have our own timeout -- see below.
                     if (time.time() - wait_start_time) > self.ready_timeout:
-                        raise TargetError('Could not acquire IP address.')
+                        raise TargetTransientError('Could not acquire IP address.')
             finally:
                 tty.sendline('exit')  # exit shell created by "su" call at the start
 

--- a/devlib/platform/gem5.py
+++ b/devlib/platform/gem5.py
@@ -19,7 +19,7 @@ import shutil
 import time
 import types
 
-from devlib.exception import TargetError
+from devlib.exception import TargetStableError
 from devlib.host import PACKAGE_BIN_DIRECTORY
 from devlib.platform import Platform
 from devlib.utils.ssh import AndroidGem5Connection, LinuxGem5Connection
@@ -86,12 +86,12 @@ class Gem5SimulationPlatform(Platform):
         Check if the command to start gem5 makes sense
         """
         if self.gem5args_binary is None:
-            raise TargetError('Please specify a gem5 binary.')
+            raise TargetStableError('Please specify a gem5 binary.')
         if self.gem5args_args is None:
-            raise TargetError('Please specify the arguments passed on to gem5.')
+            raise TargetStableError('Please specify the arguments passed on to gem5.')
         self.gem5args_virtio = str(self.gem5args_virtio).format(self.gem5_interact_dir)
         if self.gem5args_virtio is None:
-            raise TargetError('Please specify arguments needed for virtIO.')
+            raise TargetStableError('Please specify arguments needed for virtIO.')
 
     def _start_interaction_gem5(self):
         """
@@ -110,7 +110,7 @@ class Gem5SimulationPlatform(Platform):
             if not os.path.exists(self.stats_directory):
                 os.mkdir(self.stats_directory)
             if os.path.exists(self.gem5_out_dir):
-                raise TargetError("The gem5 stats directory {} already "
+                raise TargetStableError("The gem5 stats directory {} already "
                                   "exists.".format(self.gem5_out_dir))
             else:
                 os.mkdir(self.gem5_out_dir)
@@ -153,7 +153,7 @@ class Gem5SimulationPlatform(Platform):
         e.g. pid, input directory etc
         """
         self.logger("This functionality is not yet implemented")
-        raise TargetError()
+        raise TargetStableError()
 
     def _intercept_telnet_port(self):
         """
@@ -161,13 +161,13 @@ class Gem5SimulationPlatform(Platform):
         """
 
         if self.gem5 is None:
-            raise TargetError('The platform has no gem5 simulation! '
+            raise TargetStableError('The platform has no gem5 simulation! '
                               'Something went wrong')
         while self.gem5_port is None:
             # Check that gem5 is running!
             if self.gem5.poll():
                 message = "The gem5 process has crashed with error code {}!\n\tPlease see {} for details."
-                raise TargetError(message.format(self.gem5.poll(), self.stderr_file.name))
+                raise TargetStableError(message.format(self.gem5.poll(), self.stderr_file.name))
 
             # Open the stderr file
             with open(self.stderr_filename, 'r') as f:
@@ -185,7 +185,7 @@ class Gem5SimulationPlatform(Platform):
                     # Check if the sockets are not disabled
                     m = re.search(r"Sockets disabled, not accepting terminal connections", line)
                     if m:
-                        raise TargetError("The sockets have been disabled!"
+                        raise TargetStableError("The sockets have been disabled!"
                                           "Pass --listener-mode=on to gem5")
                 else:
                     time.sleep(1)
@@ -287,10 +287,10 @@ class Gem5SimulationPlatform(Platform):
 
 # Methods that will be monkey-patched onto the target
 def _overwritten_reset(self):  # pylint: disable=unused-argument
-    raise TargetError('Resetting is not allowed on gem5 platforms!')
+    raise TargetStableError('Resetting is not allowed on gem5 platforms!')
 
 def _overwritten_reboot(self):  # pylint: disable=unused-argument
-    raise TargetError('Rebooting is not allowed on gem5 platforms!')
+    raise TargetStableError('Rebooting is not allowed on gem5 platforms!')
 
 def _overwritten_capture_screen(self, filepath):
     connection_screencapped = self.platform.gem5_capture_screen(filepath)

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -23,7 +23,7 @@ import sys
 
 from devlib.trace import TraceCollector
 from devlib.host import PACKAGE_BIN_DIRECTORY
-from devlib.exception import TargetError, HostError
+from devlib.exception import TargetStableError, HostError
 from devlib.utils.misc import check_output, which
 
 
@@ -99,7 +99,7 @@ class FtraceCollector(TraceCollector):
         self.kernelshark = which('kernelshark')
 
         if not self.target.is_rooted:
-            raise TargetError('trace-cmd instrument cannot be used on an unrooted device.')
+            raise TargetStableError('trace-cmd instrument cannot be used on an unrooted device.')
         if self.autoreport and not self.report_on_target and self.host_binary is None:
             raise HostError('trace-cmd binary must be installed on the host if autoreport=True.')
         if self.autoview and self.kernelshark is None:
@@ -109,7 +109,7 @@ class FtraceCollector(TraceCollector):
             self.target_binary = self.target.install(host_file)
         else:
             if not self.target.is_installed('trace-cmd'):
-                raise TargetError('No trace-cmd found on device and no_install=True is specified.')
+                raise TargetStableError('No trace-cmd found on device and no_install=True is specified.')
             self.target_binary = 'trace-cmd'
 
         # Validate required events to be traced
@@ -127,7 +127,7 @@ class FtraceCollector(TraceCollector):
             if not list(filter(event_re.match, available_events)):
                 message = 'Event [{}] not available for tracing'.format(event)
                 if strict:
-                    raise TargetError(message)
+                    raise TargetStableError(message)
                 self.target.logger.warning(message)
             else:
                 selected_events.append(event)
@@ -142,7 +142,7 @@ class FtraceCollector(TraceCollector):
         # Check for function tracing support
         if self.functions:
             if not self.target.file_exists(self.function_profile_file):
-                raise TargetError('Function profiling not supported. '\
+                raise TargetStableError('Function profiling not supported. '\
                         'A kernel build with CONFIG_FUNCTION_PROFILER enable is required')
             # Validate required functions to be traced
             available_functions = self.target.execute(
@@ -153,7 +153,7 @@ class FtraceCollector(TraceCollector):
                 if function not in available_functions:
                     message = 'Function [{}] not available for profiling'.format(function)
                     if strict:
-                        raise TargetError(message)
+                        raise TargetStableError(message)
                     self.target.logger.warning(message)
                 else:
                     selected_functions.append(function)
@@ -283,7 +283,7 @@ class FtraceCollector(TraceCollector):
             if sys.version_info[0] == 3:
                 error = error.decode(sys.stdout.encoding, 'replace')
             if process.returncode:
-                raise TargetError('trace-cmd returned non-zero exit code {}'.format(process.returncode))
+                raise TargetStableError('trace-cmd returned non-zero exit code {}'.format(process.returncode))
             if error:
                 # logged at debug level, as trace-cmd always outputs some
                 # errors that seem benign.

--- a/devlib/trace/systrace.py
+++ b/devlib/trace/systrace.py
@@ -34,7 +34,7 @@ import subprocess
 from shutil import copyfile
 from tempfile import NamedTemporaryFile
 
-from devlib.exception import TargetError, HostError
+from devlib.exception import TargetStableError, HostError
 from devlib.trace import TraceCollector
 from devlib.utils.android import platform_tools
 from devlib.utils.misc import memoized
@@ -109,12 +109,12 @@ class SystraceCollector(TraceCollector):
             if category not in self.available_categories:
                 message = 'Category [{}] not available for tracing'.format(category)
                 if strict:
-                    raise TargetError(message)
+                    raise TargetStableError(message)
                 self.logger.warning(message)
 
         self.categories = list(set(self.categories) & set(self.available_categories))
         if not self.categories:
-            raise TargetError('None of the requested categories are available')
+            raise TargetStableError('None of the requested categories are available')
 
     def __del__(self):
         self.reset()

--- a/doc/connection.rst
+++ b/doc/connection.rst
@@ -40,7 +40,7 @@ class that implements the following methods.
    :param timeout: timeout (in seconds) for the transfer; if the transfer does
        not  complete within this period, an exception will be raised.
 
-.. method:: execute(self, command, timeout=None, check_exit_code=False, as_root=False)
+.. method:: execute(self, command, timeout=None, check_exit_code=False, as_root=False, will_succeed=False)
 
    Execute the specified command on the connected device and return its output.
 
@@ -53,6 +53,11 @@ class that implements the following methods.
        raised if it is not ``0``.
    :param as_root: The command will be executed as root. This will fail on
        unrooted connected devices.
+   :param will_succeed: The command is assumed to always succeed, unless there is
+       an issue in the environment like the loss of network connectivity. That
+       will make the method always raise an instance of a subclass of 
+       :class:`DevlibTransientError' when the command fails, instead of a
+       :class:`DevlibStableError`.
 
 .. method:: background(self, command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, as_root=False)
 
@@ -196,13 +201,12 @@ Connection Types
 
     :param host: Host on which the gem5 simulation is running
 
-                     .. note:: Even thought the input parameter for the ``host``
-                               will be ignored, the gem5 simulation needs to on
-                               the same host as the user as the user is
-                               currently on, so if the host given as input
-                               parameter is not the same as the actual host, a
-                               ``TargetError`` will be raised to prevent
-                               confusion.
+                     .. note:: Even though the input parameter for the ``host``
+                               will be ignored, the gem5 simulation needs to be
+                               on the same host the user is currently on, so if
+                               the host given as input parameter is not the
+                               same as the actual host, a ``TargetStableError``
+                               will be raised to prevent confusion.
 
     :param username: Username in the simulated system
     :param password: No password required in gem5 so does not need to be set

--- a/doc/target.rst
+++ b/doc/target.rst
@@ -232,7 +232,7 @@ Target
    :param timeout: timeout (in seconds) for the transfer; if the transfer does
        not  complete within this period, an exception will be raised.
 
-.. method:: Target.execute(command [, timeout [, check_exit_code [, as_root]]])
+.. method:: Target.execute(command [, timeout [, check_exit_code [, as_root, [will_succeed]]]])
 
    Execute the specified command on the target device and return its output.
 
@@ -245,6 +245,11 @@ Target
        raised if it is not ``0``.
    :param as_root: The command will be executed as root. This will fail on
        unrooted targets.
+   :param will_succeed: The command is assumed to always succeed, unless there is
+       an issue in the environment like the loss of network connectivity. That
+       will make the method always raise an instance of a subclass of 
+       :class:`DevlibTransientError' when the command fails, instead of a
+       :class:`DevlibStableError`.
 
 .. method:: Target.background(command [, stdout [, stderr [, as_root]]])
 


### PR DESCRIPTION
Being able to classify errors coming from transient environment issues (network failure) from actual "fixable" errors that are directly related to the logic of the code is needed for large scale automated testing. It can also be useful to write robust code that will let environment errors bubble up while only catching expected failure of the command started using Target.execute() for example. This PR classifies the TargetError exceptions into 2 categories:

- TargetTransError that reflect environment issues that are not under direct control of the devlib user.
- TargetNonTransError that reflect random issues like network failure.

Ambiguities are lifted assuming the configuration is correct, which allows normal operation in a properly set up automated environment. Incorrect configuration (e.g. network conf) could lead to raising TargetTransError even though it is not really transient.

Since TargetTransError and  TargetNonTransError both inherit from TargetError, there is no compatibility break. New code should be able to rely on a TargetError being either TargetTransError or  TargetNonTransError, but not a plain TargetError. This would otherwise lead to more except clauses than necessary in user code.

DevlibTransError and DevlibNonTransError are also added to integrate even better with TimeoutError, so generic code can use these classes as markers.
