### PR TITLE
setup.py: Change format of version to conform with PEP440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ with open(os.path.join(devlib_dir, '__init__.py')) as fh:
     version_helper = imp.load_source('version_helper', vh_path)
     commit = version_helper.get_commit()
     if commit:
-        __version__ = '{}-{}'.format(__version__, commit)
+        __version__ = '{}+{}'.format(__version__, commit)
 
 
 packages = []


### PR DESCRIPTION
When installing from source devlib attempts to include the commit ID in the
version of the installed pacakge however this caused issues with package
managers like pip. PEP440 specifies that local identifiers must be in the
form `<public version identifier>[+<localversion label>]` so update the
version to conform.

https://www.python.org/dev/peps/pep-0440/#local-version-identifiers