### PR TITLE
target: fix new line handling in os_version

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -809,7 +809,7 @@ class LinuxTarget(Target):
             for vf in version_files:
                 name = self.path.basename(vf)
                 output = self.read_value(vf)
-                os_version[name] = output.strip().replace('\n', ' ')
+                os_version[name] = convert_new_lines(output.strip()).replace('\n', ' ')
         except TargetError:
             raise
         return os_version


### PR DESCRIPTION
Use convert_new_lines() before stripping out '\n' character from OS
version strings to ensure no stray '\r's are left in.