### PR TITLE
utils/misc: Ensure outputs are converted to strings

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -192,9 +192,9 @@ def check_output(command, timeout=None, ignore=None, inputtext=None,
     retcode = process.poll()
     if retcode:
         if retcode == -9:  # killed, assume due to timeout callback
-            raise TimeoutError(command, output='\n'.join([output, error]))
+            raise TimeoutError(command, output='\n'.join([output or '', error or '']))
         elif ignore != 'all' and retcode not in ignore:
-            raise subprocess.CalledProcessError(retcode, command, output='\n'.join([str(output), str(error)]))
+            raise subprocess.CalledProcessError(retcode, command, output='\n'.join([output or '', error or '']))
     return output, error
 
 


### PR DESCRIPTION
If the process was killed, either the output or error can
be `None` which causes an error when attempting to join the outputs.