### PR TITLE
utils/version: do not decode bytes

### DIFF
--- a/devlib/utils/version.py
+++ b/devlib/utils/version.py
@@ -24,7 +24,7 @@ def get_commit():
     p.wait()
     if p.returncode:
         return None
-    if sys.version_info[0] == 3:
+    if sys.version_info[0] == 3 and isinstance(std, str):
         return std[:8].decode(sys.stdout.encoding, 'replace')
     else:
         return std[:8]


### PR DESCRIPTION
Check that the resulting output inside get_commit() is a str before
attempting to decode it when running on Python 3.