### PR TITLE
cgroups: explicitly check for proper CGroup naming

### DIFF
--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -425,6 +425,9 @@ class CgroupsModule(Module):
         :param cgroup: Name of cgroup to run command into
         :returns: A command to run `cmdline` into `cgroup`
         """
+        if not cgroup.startswith('/'):
+            message = 'cgroup name "{}" must start with "/"'.format(cgroup)
+            raise ValueError(message)
         return 'CGMOUNT={} {} cgroups_run_into {} {}'\
                 .format(self.cgroup_root, self.target.shutils,
                         cgroup, cmdline)

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -368,7 +368,7 @@ class CgroupsModule(Module):
 
         # Get the list of the available controllers
         subsys = self.list_subsystems()
-        if subsys:
+        if not subsys:
             self.logger.warning('No CGroups controller available')
             return
 


### PR DESCRIPTION
The shutils run_into support assumes that we always specify a full
cgroup path starting by "/". If, by error, we specify a cgroup name
without the leading "/" we get an ambiguous message about the cgroup not
being found.

Since this already happened to me many times, let's add an explicit
check about the cgroup name parameter to better info the user about the
requirement.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>