### PR TITLE
ssh: Use atexit to automatically close ssh connections

### DIFF
--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -237,7 +237,11 @@ class SshConnection(object):
 
     def close(self):
         logger.debug('Logging out {}@{}'.format(self.username, self.host))
-        self.conn.logout()
+        try:
+            self.conn.logout()
+        except:
+            logger.debug('Connection lost.')
+            self.conn.close(force=True)
 
     def cancel_running_command(self):
         # simulate impatiently hitting ^C until command prompt appears

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -25,6 +25,7 @@ import shutil
 import socket
 import sys
 import time
+import atexit
 
 # pylint: disable=import-error,wrong-import-position,ungrouped-imports,wrong-import-order
 import pexpect
@@ -180,6 +181,7 @@ class SshConnection(object):
         logger.debug('Logging in {}@{}'.format(username, host))
         timeout = timeout if timeout is not None else self.default_timeout
         self.conn = ssh_get_shell(host, username, password, self.keyfile, port, timeout, False, None)
+        atexit.register(self.close)
 
     def push(self, source, dest, timeout=30):
         dest = '"{}"@"{}":"{}"'.format(escape_double_quotes(self.username),


### PR DESCRIPTION
As stated in https://github.com/ARM-software/devlib/issues/308 devlib can leave ssh connections open after they are 
no longer in use, so now register the close method with atexit so the 
connections are no longer left open upon exit.