### PR TITLE
target: ignore extra lines in read_tree_values

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -660,7 +660,8 @@ class Target(object):
             if ':' not in entry:
                 continue
             path, value = entry.strip().split(':', 1)
-            result[path] = value
+            if path not in result:
+                result[path] = value
         return result
 
     def read_tree_values(self, path, depth=1, dictcls=dict, check_exit_code=True):


### PR DESCRIPTION
If a file has multiple lines the read_tree_values fn currently
returns the last line of output as the value for the file. Files
may have additional newlines in them however, so return the first
line instead in the hopes of getting the correct output.