### PR TITLE
utils/rendering: Fix Python 3 compatibility

### DIFF
--- a/devlib/utils/rendering.py
+++ b/devlib/utils/rendering.py
@@ -194,7 +194,11 @@ class GfxinfoFrameCollector(FrameCollector):
 
     def collect_frames(self, wfh):
         cmd = 'dumpsys gfxinfo {} framestats'
-        wfh.write(self.target.execute(cmd.format(self.package)))
+        result = self.target.execute(cmd.format(self.package))
+        if sys.version_info[0] == 3:
+            wfh.write(result.encode('utf-8'))
+        else:
+            wfh.write(result)
 
     def clear(self):
         pass


### PR DESCRIPTION
Add missing encoding of string when writing out fps data.