### PR TITLE
Add a fallback for sys.stdout.encoding uses

### DIFF
--- a/devlib/instrument/acmecape.py
+++ b/devlib/instrument/acmecape.py
@@ -112,7 +112,7 @@ class AcmeCapeInstrument(Instrument):
                 raise HostError(msg.format(output))
         if self.process.returncode != 15: # iio-capture exits with 15 when killed
             if sys.version_info[0] == 3:
-                output += self.process.stdout.read().decode(sys.stdout.encoding, 'replace')
+                output += self.process.stdout.read().decode(sys.stdout.encoding or 'utf-8', 'replace')
             else:
                 output += self.process.stdout.read()
             self.logger.info('ACME instrument encountered an error, '

--- a/devlib/instrument/energy_probe.py
+++ b/devlib/instrument/energy_probe.py
@@ -82,8 +82,8 @@ class EnergyProbeInstrument(Instrument):
         if self.process.returncode is not None:
             stdout, stderr = self.process.communicate()
             if sys.version_info[0] == 3:
-                stdout = stdout.decode(sys.stdout.encoding, 'replace')
-                stderr = stderr.decode(sys.stdout.encoding, 'replace')
+                stdout = stdout.decode(sys.stdout.encoding or 'utf-8', 'replace')
+                stderr = stderr.decode(sys.stdout.encoding or 'utf-8', 'replace')
             raise HostError(
                 'Energy Probe: Caiman exited unexpectedly with exit code {}.\n'
                 'stdout:\n{}\nstderr:\n{}'.format(self.process.returncode,

--- a/devlib/instrument/monsoon.py
+++ b/devlib/instrument/monsoon.py
@@ -101,8 +101,8 @@ class MonsoonInstrument(Instrument):
         if process.returncode is not None:
             stdout, stderr = process.communicate()
             if sys.version_info[0] == 3:
-                stdout = stdout.encode(sys.stdout.encoding)
-                stderr = stderr.encode(sys.stdout.encoding)
+                stdout = stdout.encode(sys.stdout.encoding or 'utf-8')
+                stderr = stderr.encode(sys.stdout.encoding or 'utf-8')
             raise HostError(
                 'Monsoon script exited unexpectedly with exit code {}.\n'
                 'stdout:\n{}\nstderr:\n{}'.format(process.returncode,

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -281,7 +281,7 @@ class FtraceCollector(TraceCollector):
             process = subprocess.Popen(command, stderr=subprocess.PIPE, shell=True)
             _, error = process.communicate()
             if sys.version_info[0] == 3:
-                error = error.decode(sys.stdout.encoding, 'replace')
+                error = error.decode(sys.stdout.encoding or 'utf-8', 'replace')
             if process.returncode:
                 raise TargetStableError('trace-cmd returned non-zero exit code {}'.format(process.returncode))
             if error:

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -152,7 +152,7 @@ class ApkInfo(object):
         try:
             output = subprocess.check_output(command, stderr=subprocess.STDOUT)
             if sys.version_info[0] == 3:
-                output = output.decode(sys.stdout.encoding, 'replace')
+                output = output.decode(sys.stdout.encoding or 'utf-8', 'replace')
         except subprocess.CalledProcessError as e:
             raise HostError('Error parsing APK file {}. `aapt` says:\n{}'
                             .format(apk_path, e.output))

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -280,7 +280,7 @@ class SshConnection(object):
         # the regex removes line breaks potential introduced when writing
         # command to shell.
         if sys.version_info[0] == 3:
-            output = process_backspaces(self.conn.before.decode(sys.stdout.encoding, 'replace'))
+            output = process_backspaces(self.conn.before.decode(sys.stdout.encoding or 'utf-8', 'replace'))
         else:
             output = process_backspaces(self.conn.before)
         output = re.sub(r'\r([^\n])', r'\1', output)

--- a/devlib/utils/types.py
+++ b/devlib/utils/types.py
@@ -153,11 +153,11 @@ if sys.version_info[0] == 3:
         if isinstance(value, regex_type):
             if isinstance(value.pattern, bytes):
                 return value
-            return re.compile(value.pattern.encode(sys.stdout.encoding),
+            return re.compile(value.pattern.encode(sys.stdout.encoding or 'utf-8'),
                               value.flags & ~re.UNICODE)
         else:
             if isinstance(value, str):
-                value = value.encode(sys.stdout.encoding)
+                value = value.encode(sys.stdout.encoding or 'utf-8')
             return re.compile(value)
 else:
     def regex(value):

--- a/devlib/utils/version.py
+++ b/devlib/utils/version.py
@@ -25,6 +25,6 @@ def get_commit():
     if p.returncode:
         return None
     if sys.version_info[0] == 3 and isinstance(std, bytes):
-        return std[:8].decode(sys.stdout.encoding, 'replace')
+        return std[:8].decode(sys.stdout.encoding or 'utf-8', 'replace')
     else:
         return std[:8]


### PR DESCRIPTION
In some environments (e.g. nosetest), sys.stdout.encoding can be None.
Add a fallback to handle these cases.

For some weird reason https://github.com/ARM-software/devlib/pull/322 closed itself when I updated my branch, and I couldn't re-open it...

I didn't find a wait to stop nosetest from fiddling with `sys.stdout.encoding`, so I just went with sed'ing all of its uses and adding a `or 'utf-8'` to it, as is already done in `utils/misc.py`. Not the cleanest solution but it lets me run my tests for now, so I updated the PR to have that.