### PR TITLE
module/sched: Fix sched procfs parsing for >= 10 CPU systems

### DIFF
--- a/devlib/module/sched.py
+++ b/devlib/module/sched.py
@@ -48,7 +48,7 @@ class SchedProcFSNode(object):
     MC
     """
 
-    _re_procfs_node = re.compile(r"(?P<name>.*)(?P<digits>\d+)$")
+    _re_procfs_node = re.compile(r"(?P<name>.*\D)(?P<digits>\d+)$")
 
     @staticmethod
     def _ends_with_digits(node):


### PR DESCRIPTION
The regexp was a bit too greedy and would match 'cpu1' as the
name of a 'cpu10' node.