### PR TITLE
target: Fix number_of_cpus() on targets with a coloured prompt

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -140,10 +140,13 @@ class Target(object):
     def number_of_cpus(self):
         num_cpus = 0
         corere = re.compile(r'^\s*cpu\d+\s*$')
-        output = self.execute('ls /sys/devices/system/cpu')
+        output = self.execute('ls --color=never /sys/devices/system/cpu')
         for entry in output.split():
             if corere.match(entry):
                 num_cpus += 1
+
+        if not num_cpus:
+            raise TargetStableError('The number of CPUs cannot be null')
         return num_cpus
 
     @property


### PR DESCRIPTION
On some Linux targets, the 'ls' command has a coloured output by
default. Since number_of_cpus() performs a regex on the output of that
command, the color codes around the name of files and directories can
cause issues. target.execute('ls /sys/devices/system/cpu') on my juno
will provide '\x1b[01;34mcpu1\x1b[0m' instead of 'cpu1', for example.
Because of this, number_of_cpus() can return 0.

Fix this with by forcing '--color=never' in ls. While at it, make sure
to raise a human-readable exception in case number_of_cpus() is null,
since this is always wrong, and can lead to pretty nasty and hard-to-debug
cases.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>