### PR TITLE
module/sched: Harden probe()

### DIFF
--- a/devlib/module/sched.py
+++ b/devlib/module/sched.py
@@ -195,7 +195,19 @@ class SchedProcFSData(SchedProcFSNode):
 
     @staticmethod
     def available(target):
-        return target.directory_exists(SchedProcFSData.sched_domain_root)
+        path = SchedProcFSData.sched_domain_root
+        cpus = target.list_directory(path) if target.file_exists(path) else []
+
+        if not cpus:
+            return False
+
+        # Even if we have a CPU entry, it can be empty (e.g. hotplugged out)
+        # Make sure some data is there
+        for cpu in cpus:
+            if target.file_exists(target.path.join(path, cpu, "domain0", "name")):
+                return True
+
+        return False
 
     def __init__(self, target, path=None):
         if not path:


### PR DESCRIPTION
Running some tests on a VM I hit that unexpected scenario where the
required sched_domain file is there but then read_tree_values() fails
because there are no files to read, only directories.

This does a quick check that there's actual data to be read.