### PR TITLE
[RFC] Fix quoting

### DIFF
--- a/devlib/host.py
+++ b/devlib/host.py
@@ -20,6 +20,7 @@ import subprocess
 import logging
 from distutils.dir_util import copy_tree
 from getpass import getpass
+from pipes import quote
 
 from devlib.exception import TargetTransientError, TargetStableError
 from devlib.utils.misc import check_output
@@ -70,7 +71,7 @@ class LocalConnection(object):
             if self.unrooted:
                 raise TargetStableError('unrooted')
             password = self._get_password()
-            command = 'echo \'{}\' | sudo -S '.format(password) + command
+            command = 'echo {} | sudo -S '.format(quote(password)) + command
         ignore = None if check_exit_code else 'all'
         try:
             return check_output(command, shell=True, timeout=timeout, ignore=ignore)[0]
@@ -87,7 +88,7 @@ class LocalConnection(object):
             if self.unrooted:
                 raise TargetStableError('unrooted')
             password = self._get_password()
-            command = 'echo \'{}\' | sudo -S '.format(password) + command
+            command = 'echo {} | sudo -S '.format(quote(password)) + command
         return subprocess.Popen(command, stdout=stdout, stderr=stderr, shell=True)
 
     def close(self):

--- a/devlib/instrument/acmecape.py
+++ b/devlib/instrument/acmecape.py
@@ -19,6 +19,7 @@ import os
 import sys
 import time
 import tempfile
+import shlex
 from fcntl import fcntl, F_GETFL, F_SETFL
 from string import Template
 from subprocess import Popen, PIPE, STDOUT
@@ -95,7 +96,7 @@ class AcmeCapeInstrument(Instrument):
         self.logger.debug('ACME cape command: {}'.format(self.command))
 
     def start(self):
-        self.process = Popen(self.command.split(), stdout=PIPE, stderr=STDOUT)
+        self.process = Popen(shlex.split(self.command), stdout=PIPE, stderr=STDOUT)
 
     def stop(self):
         self.process.terminate()

--- a/devlib/instrument/acmecape.py
+++ b/devlib/instrument/acmecape.py
@@ -22,6 +22,7 @@ import tempfile
 from fcntl import fcntl, F_GETFL, F_SETFL
 from string import Template
 from subprocess import Popen, PIPE, STDOUT
+from pipes import quote
 
 from devlib import Instrument, CONTINUOUS, MeasurementsCsv
 from devlib.exception import HostError
@@ -89,6 +90,7 @@ class AcmeCapeInstrument(Instrument):
             iio_device=self.iio_device,
             outfile=self.raw_data_file
         )
+        params = {k: quote(v) for k, v in params.items()}
         self.command = IIOCAP_CMD_TEMPLATE.substitute(**params)
         self.logger.debug('ACME cape command: {}'.format(self.command))
 

--- a/devlib/instrument/arm_energy_probe.py
+++ b/devlib/instrument/arm_energy_probe.py
@@ -34,6 +34,7 @@ from __future__ import division
 import os
 import subprocess
 import signal
+from pipes import quote
 
 import tempfile
 import shutil
@@ -97,7 +98,7 @@ class ArmEnergyProbeInstrument(Instrument):
         self.output_file_figure = os.path.join(self.output_directory, 'summary.txt')
         self.output_file_error = os.path.join(self.output_directory, 'error.log')
         self.output_fd_error = open(self.output_file_error, 'w')
-        self.command = 'arm-probe --config {} > {}'.format(self.config_file, self.output_file_raw)
+        self.command = 'arm-probe --config {} > {}'.format(quote(self.config_file), quote(self.output_file_raw))
 
     def start(self):
         self.logger.debug(self.command)

--- a/devlib/instrument/energy_probe.py
+++ b/devlib/instrument/energy_probe.py
@@ -19,6 +19,7 @@ import tempfile
 import struct
 import subprocess
 import sys
+from pipes import quote
 
 from devlib.instrument import Instrument, CONTINUOUS, MeasurementsCsv
 from devlib.exception import HostError
@@ -65,7 +66,10 @@ class EnergyProbeInstrument(Instrument):
         parts = ['-r {}:{} '.format(i, int(1000 * rval))
                  for i, rval in enumerate(self.resistor_values)]
         rstring = ''.join(parts)
-        self.command = '{} -d {} -l {} {}'.format(self.caiman, self.device_entry, rstring, self.raw_output_directory)
+        self.command = '{} -d {} -l {} {}'.format(
+            quote(self.caiman), quote(self.device_entry),
+            rstring, quote(self.raw_output_directory)
+        )
         self.raw_data_file = None
 
     def start(self):

--- a/devlib/platform/gem5.py
+++ b/devlib/platform/gem5.py
@@ -18,6 +18,7 @@ import subprocess
 import shutil
 import time
 import types
+import shlex
 from pipes import quote
 
 from devlib.exception import TargetStableError
@@ -134,7 +135,7 @@ class Gem5SimulationPlatform(Platform):
                                                          self.gem5args_args,
                                                          self.gem5args_virtio)
             self.logger.debug("gem5 command line: {}".format(command_line))
-            self.gem5 = subprocess.Popen(command_line.split(),
+            self.gem5 = subprocess.Popen(shlex.split(command_line),
                                          stdout=self.stdout_file,
                                          stderr=self.stderr_file)
 

--- a/devlib/platform/gem5.py
+++ b/devlib/platform/gem5.py
@@ -18,6 +18,7 @@ import subprocess
 import shutil
 import time
 import types
+from pipes import quote
 
 from devlib.exception import TargetStableError
 from devlib.host import PACKAGE_BIN_DIRECTORY
@@ -129,7 +130,7 @@ class Gem5SimulationPlatform(Platform):
             self.logger.info("Starting the gem5 simulator")
 
             command_line = "{} --outdir={} {} {}".format(self.gem5args_binary,
-                                                         self.gem5_out_dir,
+                                                         quote(self.gem5_out_dir),
                                                          self.gem5args_args,
                                                          self.gem5args_virtio)
             self.logger.debug("gem5 command line: {}".format(command_line))

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -26,6 +26,7 @@ import threading
 import xml.dom.minidom
 import copy
 from collections import namedtuple, defaultdict
+from pipes import quote
 
 from devlib.host import LocalConnection, PACKAGE_BIN_DIRECTORY
 from devlib.module import get_module
@@ -36,7 +37,7 @@ from devlib.exception import (DevlibTransientError, TargetStableError,
 from devlib.utils.ssh import SshConnection
 from devlib.utils.android import AdbConnection, AndroidProperties, LogcatMonitor, adb_command, adb_disconnect, INTENT_FLAGS
 from devlib.utils.misc import memoized, isiterable, convert_new_lines
-from devlib.utils.misc import commonprefix, escape_double_quotes, merge_lists
+from devlib.utils.misc import commonprefix, merge_lists
 from devlib.utils.misc import ABI_MAP, get_cpu_name, ranges_to_list
 from devlib.utils.types import integer, boolean, bitmask, identifier, caseless_string, bytes_regex
 
@@ -555,7 +556,7 @@ class Target(object):
         raise IOError('No usable temporary filename found')
 
     def remove(self, path, as_root=False):
-        self.execute('rm -rf "{}"'.format(escape_double_quotes(path)), as_root=as_root)
+        self.execute('rm -rf {}'.format(quote(path)), as_root=as_root)
 
     # misc
     def core_cpus(self, core):
@@ -891,7 +892,7 @@ class LinuxTarget(Target):
         pass
 
     def kick_off(self, command, as_root=False):
-        command = 'sh -c "{}" 1>/dev/null 2>/dev/null &'.format(escape_double_quotes(command))
+        command = 'sh -c {} 1>/dev/null 2>/dev/null &'.format(quote(command))
         return self.conn.execute(command, as_root=as_root)
 
     def get_pids_of(self, process_name):
@@ -925,7 +926,7 @@ class LinuxTarget(Target):
             return filtered_result
 
     def list_directory(self, path, as_root=False):
-        contents = self.execute('ls -1 "{}"'.format(escape_double_quotes(path)), as_root=as_root)
+        contents = self.execute('ls -1 {}'.format(quote(path)), as_root=as_root)
         return [x.strip() for x in contents.split('\n') if x.strip()]
 
     def install(self, filepath, timeout=None, with_name=None):  # pylint: disable=W0221
@@ -1522,13 +1523,13 @@ class AndroidTarget(Target):
             if it is already running
         :type force_new: bool
         """
-        cmd = 'am start -a android.intent.action.VIEW -d "{}"'
+        cmd = 'am start -a android.intent.action.VIEW -d {}'
 
         if force_new:
             cmd = cmd + ' -f {}'.format(INTENT_FLAGS['ACTIVITY_NEW_TASK'] |
                                         INTENT_FLAGS['ACTIVITY_CLEAR_TASK'])
 
-        self.execute(cmd.format(escape_double_quotes(url)))
+        self.execute(cmd.format(quote(url)))
 
     def homescreen(self):
         self.execute('am start -a android.intent.action.MAIN -c android.intent.category.HOME')

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -235,7 +235,7 @@ class AdbConnection(object):
     def push(self, source, dest, timeout=None):
         if timeout is None:
             timeout = self.timeout
-        command = "push '{}' '{}'".format(source, dest)
+        command = "push {} {}".format(quote(source), quote(dest))
         if not os.path.exists(source):
             raise HostError('No such file "{}"'.format(source))
         return adb_command(self.device, command, timeout=timeout, adb_server=self.adb_server)
@@ -249,10 +249,10 @@ class AdbConnection(object):
             command = 'shell {} {}'.format(self.ls_command, source)
             output = adb_command(self.device, command, timeout=timeout, adb_server=self.adb_server)
             for line in output.splitlines():
-                command = "pull '{}' '{}'".format(line.strip(), dest)
+                command = "pull {} {}".format(quote(line.strip()), quote(dest))
                 adb_command(self.device, command, timeout=timeout, adb_server=self.adb_server)
             return
-        command = "pull '{}' '{}'".format(source, dest)
+        command = "pull {} {}".format(quote(source), quote(dest))
         return adb_command(self.device, command, timeout=timeout, adb_server=self.adb_server)
 
     # pylint: disable=unused-argument
@@ -285,7 +285,7 @@ class AdbConnection(object):
 
 def fastboot_command(command, timeout=None, device=None):
     _check_env()
-    target = '-s {}'.format(device) if device else ''
+    target = '-s {}'.format(quote(device)) if device else ''
     full_command = 'fastboot {} {}'.format(target, command)
     logger.debug(full_command)
     output, _ = check_output(full_command, timeout, shell=True)
@@ -293,7 +293,7 @@ def fastboot_command(command, timeout=None, device=None):
 
 
 def fastboot_flash_partition(partition, path_to_image):
-    command = 'flash {} {}'.format(partition, path_to_image)
+    command = 'flash {} {}'.format(quote(partition), quote(path_to_image))
     fastboot_command(command)
 
 
@@ -341,7 +341,7 @@ def adb_connect(device, timeout=None, attempts=MAX_ATTEMPTS):
         tries += 1
         if device:
             if "." in device: # Connect is required only for ADB-over-IP
-                command = 'adb connect {}'.format(device)
+                command = 'adb connect {}'.format(quote(device))
                 logger.debug(command)
                 output, _ = check_output(command, shell=True, timeout=timeout)
         if _ping(device):
@@ -368,7 +368,7 @@ def adb_disconnect(device):
 
 def _ping(device):
     _check_env()
-    device_string = ' -s {}'.format(device) if device else ''
+    device_string = ' -s {}'.format(quote(device)) if device else ''
     command = "adb{} shell \"ls /data/local/tmp > /dev/null\"".format(device_string)
     logger.debug(command)
     result = subprocess.call(command, stderr=subprocess.PIPE, shell=True)
@@ -610,9 +610,9 @@ class LogcatMonitor(object):
             # Logcat on older version of android do not support the -e argument
             # so fall back to using grep.
             if self.target.get_sdk_version() > 23:
-                logcat_cmd = '{} -e "{}"'.format(logcat_cmd, regexp)
+                logcat_cmd = '{} -e {}'.format(logcat_cmd, quote(regexp))
             else:
-                logcat_cmd = '{} | grep "{}"'.format(logcat_cmd, regexp)
+                logcat_cmd = '{} | grep {}'.format(logcat_cmd, quote(regexp))
 
         logcat_cmd = get_adb_command(self.target.conn.device, logcat_cmd)
 

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -28,10 +28,10 @@ import tempfile
 import subprocess
 from collections import defaultdict
 import pexpect
+from pipes import quote
 
 from devlib.exception import TargetTransientError, TargetStableError, HostError
 from devlib.utils.misc import check_output, which, ABI_MAP
-from devlib.utils.misc import escape_single_quotes, escape_double_quotes
 
 
 logger = logging.getLogger('android')
@@ -383,7 +383,7 @@ def adb_shell(device, command, timeout=None, check_exit_code=False,
               as_root=False, adb_server=None):  # NOQA
     _check_env()
     if as_root:
-        command = 'echo \'{}\' | su'.format(escape_single_quotes(command))
+        command = 'echo {} | su'.format(quote(command))
     device_part = []
     if adb_server:
         device_part = ['-H', adb_server]
@@ -443,9 +443,9 @@ def adb_background_shell(device, command,
     """Runs the sepcified command in a subprocess, returning the the Popen object."""
     _check_env()
     if as_root:
-        command = 'echo \'{}\' | su'.format(escape_single_quotes(command))
+        command = 'echo {} | su'.format(quote(command))
     device_string = ' -s {}'.format(device) if device else ''
-    full_command = 'adb{} shell "{}"'.format(device_string, escape_double_quotes(command))
+    full_command = 'adb{} shell {}'.format(device_string, quote(command))
     logger.debug(full_command)
     return subprocess.Popen(full_command, stdout=stdout, stderr=stderr, shell=True)
 

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -35,6 +35,7 @@ import subprocess
 import sys
 import threading
 import wrapt
+import warnings
 
 
 from past.builtins import basestring
@@ -416,6 +417,16 @@ def convert_new_lines(text):
     """ Convert new lines to a common format.  """
     return text.replace('\r\n', '\n').replace('\r', '\n')
 
+def sanitize_cmd_template(cmd):
+    msg = (
+        '''Quoted placeholder should not be used, as it will result in quoting the text twice. {} should be used instead of '{}' or "{}" in the template: '''
+    )
+    for unwanted in ('"{}"', "'{}'"):
+        if unwanted in cmd:
+            warnings.warn(msg + cmd, stacklevel=2)
+            cmd = cmd.replace(unwanted, '{}')
+
+    return cmd
 
 def escape_quotes(text):
     """Escape quotes, and escaped quotes, in the specified text."""

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -429,22 +429,38 @@ def sanitize_cmd_template(cmd):
     return cmd
 
 def escape_quotes(text):
-    """Escape quotes, and escaped quotes, in the specified text."""
+    """
+    Escape quotes, and escaped quotes, in the specified text.
+
+    .. note:: :func:`pipes.quote` should be favored where possible.
+    """
     return re.sub(r'\\("|\')', r'\\\\\1', text).replace('\'', '\\\'').replace('\"', '\\\"')
 
 
 def escape_single_quotes(text):
-    """Escape single quotes, and escaped single quotes, in the specified text."""
+    """
+    Escape single quotes, and escaped single quotes, in the specified text.
+
+    .. note:: :func:`pipes.quote` should be favored where possible.
+    """
     return re.sub(r'\\("|\')', r'\\\\\1', text).replace('\'', '\'\\\'\'')
 
 
 def escape_double_quotes(text):
-    """Escape double quotes, and escaped double quotes, in the specified text."""
+    """
+    Escape double quotes, and escaped double quotes, in the specified text.
+
+    .. note:: :func:`pipes.quote` should be favored where possible.
+    """
     return re.sub(r'\\("|\')', r'\\\\\1', text).replace('\"', '\\\"')
 
 
 def escape_spaces(text):
-    """Escape spaces in the specified text"""
+    """
+    Escape spaces in the specified text
+
+    .. note:: :func:`pipes.quote` should be favored where possible.
+    """
     return text.replace(' ', '\ ')
 
 

--- a/devlib/utils/rendering.py
+++ b/devlib/utils/rendering.py
@@ -21,6 +21,7 @@ import tempfile
 import threading
 import time
 from collections import namedtuple
+from pipes import quote
 
 # pylint: disable=redefined-builtin
 from devlib.exception  import WorkerThreadError, TargetNotRespondingError, TimeoutError
@@ -138,8 +139,8 @@ class SurfaceFlingerFrameCollector(FrameCollector):
         self.target.execute('dumpsys SurfaceFlinger --latency-clear ')
 
     def get_latencies(self, activity):
-        cmd = 'dumpsys SurfaceFlinger --latency "{}"'
-        return self.target.execute(cmd.format(activity))
+        cmd = 'dumpsys SurfaceFlinger --latency {}'
+        return self.target.execute(cmd.format(quote(activity)))
 
     def list(self):
         text = self.target.execute('dumpsys SurfaceFlinger --list')

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -26,6 +26,7 @@ import socket
 import sys
 import time
 import atexit
+from pipes import quote
 
 # pylint: disable=import-error,wrong-import-position,ungrouped-imports,wrong-import-order
 import pexpect
@@ -39,7 +40,7 @@ from pexpect import EOF, TIMEOUT, spawn
 # pylint: disable=redefined-builtin,wrong-import-position
 from devlib.exception import (HostError, TargetStableError, TargetNotRespondingError,
                               TimeoutError, TargetTransientError)
-from devlib.utils.misc import which, strip_bash_colors, check_output
+from devlib.utils.misc import which, strip_bash_colors, check_output, sanitize_cmd_template
 from devlib.utils.misc import (escape_single_quotes, escape_double_quotes,
                                escape_spaces)
 from devlib.utils.types import boolean
@@ -169,7 +170,7 @@ class SshConnection(object):
                  password_prompt=None,
                  original_prompt=None,
                  platform=None,
-                 sudo_cmd="sudo -- sh -c '{}'"
+                 sudo_cmd="sudo -- sh -c {}"
                  ):
         self.host = host
         self.username = username
@@ -178,22 +179,18 @@ class SshConnection(object):
         self.port = port
         self.lock = threading.Lock()
         self.password_prompt = password_prompt if password_prompt is not None else self.default_password_prompt
-        self.sudo_cmd = sudo_cmd
+        self.sudo_cmd = sanitize_cmd_template(sudo_cmd)
         logger.debug('Logging in {}@{}'.format(username, host))
         timeout = timeout if timeout is not None else self.default_timeout
         self.conn = ssh_get_shell(host, username, password, self.keyfile, port, timeout, False, None)
         atexit.register(self.close)
 
     def push(self, source, dest, timeout=30):
-        dest = '"{}"@"{}":"{}"'.format(escape_double_quotes(self.username),
-                                       escape_spaces(escape_double_quotes(self.host)),
-                                       escape_spaces(escape_double_quotes(dest)))
+        dest = '{}@{}:{}'.format(self.username, self.host, dest)
         return self._scp(source, dest, timeout)
 
     def pull(self, source, dest, timeout=30):
-        source = '"{}"@"{}":"{}"'.format(escape_double_quotes(self.username),
-                                         escape_spaces(escape_double_quotes(self.host)),
-                                         escape_spaces(escape_double_quotes(source)))
+        source = '{}@{}:{}'.format(self.username, self.host, source)
         return self._scp(source, dest, timeout)
 
     def execute(self, command, timeout=None, check_exit_code=True,
@@ -240,7 +237,7 @@ class SshConnection(object):
             command = '{} {} {} {}@{} {}'.format(ssh, keyfile_string, port_string, self.username, self.host, command)
             logger.debug(command)
             if self.password:
-                command = _give_password(self.password, command)
+                command, _ = _give_password(self.password, command)
             return subprocess.Popen(command, stdout=stdout, stderr=stderr, shell=True)
         except EOF:
             raise TargetNotRespondingError('Connection lost.')
@@ -310,14 +307,13 @@ class SshConnection(object):
         # fails to connect to a device if port is explicitly specified using -P
         # option, even if it is the default port, 22. To minimize this problem,
         # only specify -P for scp if the port is *not* the default.
-        port_string = '-P {}'.format(self.port) if (self.port and self.port != 22) else ''
-        keyfile_string = '-i {}'.format(self.keyfile) if self.keyfile else ''
-        command = '{} -r {} {} {} {}'.format(scp, keyfile_string, port_string, source, dest)
+        port_string = '-P {}'.format(quote(str(self.port))) if (self.port and self.port != 22) else ''
+        keyfile_string = '-i {}'.format(quote(self.keyfile)) if self.keyfile else ''
+        command = '{} -r {} {} {} {}'.format(scp, keyfile_string, port_string, quote(source), quote(dest))
         command_redacted = command
         logger.debug(command)
         if self.password:
-            command = _give_password(self.password, command)
-            command_redacted = command.replace(self.password, '<redacted>')
+            command, command_redacted = _give_password(self.password, command)
         try:
             check_output(command, timeout=timeout, shell=True)
         except subprocess.CalledProcessError as e:
@@ -456,13 +452,12 @@ class Gem5Connection(TelnetConnection):
         if os.path.basename(dest) != filename:
             dest = os.path.join(dest, filename)
         # Back to the gem5 world
-        self._gem5_shell("ls -al {}{}".format(self.gem5_input_dir, filename))
-        self._gem5_shell("cat '{}''{}' > '{}'".format(self.gem5_input_dir,
-                                                     filename,
-                                                     dest))
+        filename = quote(self.gem5_input_dir + filename)
+        self._gem5_shell("ls -al {}".format(filename))
+        self._gem5_shell("cat {} > {}".format(filename, quote(dest)))
         self._gem5_shell("sync")
-        self._gem5_shell("ls -al {}".format(dest))
-        self._gem5_shell("ls -al {}".format(self.gem5_input_dir))
+        self._gem5_shell("ls -al {}".format(quote(dest)))
+        self._gem5_shell("ls -al {}".format(quote(self.gem5_input_dir)))
         logger.debug("Push complete.")
 
     def pull(self, source, dest, timeout=0): #pylint: disable=unused-argument
@@ -491,8 +486,8 @@ class Gem5Connection(TelnetConnection):
             if os.path.isabs(source):
                 if os.path.dirname(source) != self.execute('pwd',
                                               check_exit_code=False):
-                    self._gem5_shell("cat '{}' > '{}'".format(filename,
-                                                              dest_file))
+                    self._gem5_shell("cat {} > {}".format(quote(filename),
+                                                              quote(dest_file)))
             self._gem5_shell("sync")
             self._gem5_shell("ls -la {}".format(dest_file))
             logger.debug('Finished the copy in the simulator')
@@ -875,7 +870,8 @@ class Gem5Connection(TelnetConnection):
         """
         Internal method to check if the target has a certain file
         """
-        command = 'if [ -e \'{}\' ]; then echo 1; else echo 0; fi'
+        filepath = quote(filepath)
+        command = 'if [ -e {} ]; then echo 1; else echo 0; fi'
         output = self.execute(command.format(filepath), as_root=self.is_rooted)
         return boolean(output.strip())
 
@@ -931,8 +927,10 @@ class AndroidGem5Connection(Gem5Connection):
 def _give_password(password, command):
     if not sshpass:
         raise HostError('Must have sshpass installed on the host in order to use password-based auth.')
-    pass_string = "sshpass -p '{}' ".format(password)
-    return pass_string + command
+    pass_template = "sshpass -p {} "
+    pass_string = pass_template.format(quote(password))
+    redacted_string = pass_template.format(quote('<redacted>'))
+    return (pass_string + command, redacted_string + command)
 
 
 def _check_env():

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -41,8 +41,6 @@ from pexpect import EOF, TIMEOUT, spawn
 from devlib.exception import (HostError, TargetStableError, TargetNotRespondingError,
                               TimeoutError, TargetTransientError)
 from devlib.utils.misc import which, strip_bash_colors, check_output, sanitize_cmd_template
-from devlib.utils.misc import (escape_single_quotes, escape_double_quotes,
-                               escape_spaces)
 from devlib.utils.types import boolean
 
 
@@ -265,7 +263,7 @@ class SshConnection(object):
             # As we're already root, there is no need to use sudo.
             as_root = False
         if as_root:
-            command = self.sudo_cmd.format(escape_single_quotes(command))
+            command = self.sudo_cmd.format(quote(command))
             if log:
                 logger.debug(command)
             self.conn.sendline(command)
@@ -758,7 +756,7 @@ class Gem5Connection(TelnetConnection):
         gem5_logger.debug("gem5_shell command: {}".format(command))
 
         if as_root:
-            command = 'echo "{}" | su'.format(escape_double_quotes(command))
+            command = 'echo {} | su'.format(quote(command))
 
         # Send the actual command
         self.conn.send("{}\n".format(command))


### PR DESCRIPTION
This PR address some quoting issues in various places where a string containing a command is fed to a shell, directly or indirectly e.g. through `su`.

The third commit "escaping: Use pipes.quote instead of escape_*" unifies escaping in devlib so that the strings provided to the library are used as is, without further interpolation. That could break code relying on referencing environment variable in provided strings, and code that manually escapes strings in order to work around that. It should be noted that any calling code can make use of `os.path.expandvars` to interpolate env var, and that devlib seems to use both single and double quoting in various places, without clear documented consistency.

This PR was tested on SSH connections for a LinuxTarget only, so it would benefit from broader testing and/or close code inspection.

The original issue is Target.push/pull, that cannot deal correctly with paths containing `(` and `)`:
```
  File "/home/dourai01/Data/Git/lisa/py3k/modules_root/devlib/target.py", line 313, in push
    self.conn.push(source, dest, timeout=timeout)
  File "/home/dourai01/Data/Git/lisa/py3k/modules_root/devlib/utils/ssh.py", line 191, in push
    return self._scp(source, dest, timeout)
  File "/home/dourai01/Data/Git/lisa/py3k/modules_root/devlib/utils/ssh.py", line 321, in _scp
    command_redacted, e.output))
devlib.exception.HostError: Failed to copy file with '/usr/bin/scp -r -i /tmp/id_rsa  /home/dourai01/Data/Git/lisa/py3k/results/20181112_11:33:24_02ebf5b9de5d48c7a296d1f773596551/PELTTaskTest.test_load_avg_range/PELTTaskTest:test_load_avg_range(allowed_error_pct=ForcedType)/e95235eb4fe34c21837516f51b67fd5b/lisa.env.TestEnv/1/rta_calib-20181112_113350.106580/rta_calib_cpu0.json "root"@"pwrsft-hikey620-1":"/root/devlib-target/rta_calib_cpu0.json"'. Output:
```