### PR TITLE
instrument: Fix active_channels for Python 3

### DIFF
--- a/devlib/instrument/__init__.py
+++ b/devlib/instrument/__init__.py
@@ -320,7 +320,7 @@ class Instrument(object):
 
             wanted = lambda ch: ((kinds is None or ch.kind in kinds) and
                                   (sites is None or ch.site in sites))
-            self.active_channels = filter(wanted, self.channels.values())
+            self.active_channels = list(filter(wanted, self.channels.values()))
 
     # instantaneous
 


### PR DESCRIPTION
Since we can iterate over the active_channel attribute of Instrument
more than once, make sure to cast the return value of filter() to a list
to avoid issues with python 3.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>