### PR TITLE
serial_port: Handle exception in open_serial_connection

### DIFF
--- a/devlib/utils/serial_port.py
+++ b/devlib/utils/serial_port.py
@@ -114,10 +114,13 @@ def open_serial_connection(timeout, get_conn=False, init_dtr=None,
     """
     target, conn = get_connection(timeout, init_dtr=init_dtr,
                                   logcls=logcls, *args, **kwargs)
-    if get_conn:
-        yield target, conn
-    else:
-        yield target
 
-    target.close()  # Closes the file descriptor used by the conn.
-    del conn
+    if get_conn:
+        target_and_conn = (target, conn)
+    else:
+        target_and_conn = target
+
+    try:
+        yield target_and_conn
+    finally:
+        target.close()  # Closes the file descriptor used by the conn.


### PR DESCRIPTION
Use try/finally clause in the contextmanager to always close the
connection if an exception is raised.

Also remove "del conn" since it only decrements the reference count,
which is done anyway when the generator function returns.