### PR TITLE
cgroups: allow to set dot-named attributes

### DIFF
--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -302,7 +302,8 @@ class CGroup(object):
 
         return conf
 
-    def set(self, **attrs):
+    def set(self, *args, **attrs):
+        attrs.update(args)
         for idx in attrs:
             if isiterable(attrs[idx]):
                 attrs[idx] = list_to_ranges(attrs[idx])


### PR DESCRIPTION
Certain controller, especially on CGroups v2, uses attributes whith a
"dot" in their name, e.g. "cpus.allowed". Unfortunately, those are not
valid function parameter names in Python.

Let's fix this by allowing to define those attributes as (key, value)
tuples. Thus, for example, it will be possible use the simplest call for
each attribute we want to configure:

   cg.set(cpus="0-5", ("cpus.allowed", "1,2"))

Suggested-by: Douglas Raillard <douglas.raillard@arm.com>
Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>