### PR TITLE
cgroups.py: strip slashes, don't drop first char

### DIFF
--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -262,8 +262,9 @@ class CGroup(object):
 
         # Control cgroup path
         self.directory = controller.mount_point
+
         if name != '/':
-            self.directory = self.target.path.join(controller.mount_point, name[1:])
+            self.directory = self.target.path.join(controller.mount_point, name.strip('/'))
 
         # Setup path for tasks file
         self.tasks_file = self.target.path.join(self.directory, 'tasks')


### PR DESCRIPTION
this makes it cope with both, names starting with or without slashes.

currently, if you omit the leading slash, it will just remove the first character of the directory instead, which is annoying.

the trailing slash isn't needed, if i'm wrong could lstrip() instead...