### PR TITLE
ApkInfo: Dynamically extract activities and class methods

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -147,15 +147,7 @@ class ApkInfo(object):
     # pylint: disable=too-many-branches
     def parse(self, apk_path):
         _check_env()
-        command = [aapt, 'dump', 'badging', apk_path]
-        logger.debug(' '.join(command))
-        try:
-            output = subprocess.check_output(command, stderr=subprocess.STDOUT)
-            if sys.version_info[0] == 3:
-                output = output.decode(sys.stdout.encoding or 'utf-8', 'replace')
-        except subprocess.CalledProcessError as e:
-            raise HostError('Error parsing APK file {}. `aapt` says:\n{}'
-                            .format(apk_path, e.output))
+        output = self._run([aapt, 'dump', 'badging', apk_path])
         for line in output.split('\n'):
             if line.startswith('application-label:'):
                 self.label = line.split(':')[1].strip().replace('\'', '')
@@ -187,6 +179,17 @@ class ApkInfo(object):
                     self.permissions.append(match.group('permission'))
             else:
                 pass  # not interested
+
+    def _run(self, command):
+        logger.debug(' '.join(command))
+        try:
+            output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+            if sys.version_info[0] == 3:
+                output = output.decode(sys.stdout.encoding or 'utf-8', 'replace')
+        except subprocess.CalledProcessError as e:
+            raise HostError('Error while running "{}":\n{}'
+                            .format(command, e.output))
+        return output
 
 
 class AdbConnection(object):

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -132,6 +132,7 @@ class ApkInfo(object):
     version_regex = re.compile(r"name='(?P<name>[^']+)' versionCode='(?P<vcode>[^']+)' versionName='(?P<vname>[^']+)'")
     name_regex = re.compile(r"name='(?P<name>[^']+)'")
     permission_regex = re.compile(r"name='(?P<permission>[^']+)'")
+    activity_regex = re.compile(r'\s*A:\s*android:name\(0x\d+\)=".(?P<name>\w+)"')
 
     def __init__(self, path=None):
         self.path = path
@@ -179,6 +180,18 @@ class ApkInfo(object):
                     self.permissions.append(match.group('permission'))
             else:
                 pass  # not interested
+
+        self._apk_path = apk_path
+        self._activities = None
+
+    @property
+    def activities(self):
+        if self._activities is None:
+            cmd = [aapt, 'dump', 'xmltree', self._apk_path,
+                   'AndroidManifest.xml']
+            matched_activities = self.activity_regex.finditer(self._run(cmd))
+            self._activities = [m.group('name') for m in matched_activities]
+        return self._activities
 
     def _run(self, command):
         logger.debug(' '.join(command))


### PR DESCRIPTION
Add support to `ApkInfo` for dynamically extracting:
- Application activities;
- Methods from each class packed in the APK.

Because of the added requirement for using the Android SDK, refactor in an `ApkInfo._run` method for CLI calls.

NB: This PR contains relatively distinct commits and could be broken down into 2 (or 3?) PRs, if necessary...