### PR TITLE
target: Fix read_tree_values() with ':' in path

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -242,26 +242,32 @@ hotplug_online_all() {
 # Misc
 ################################################################################
 
-read_tree_values() {
+read_tree_tgz_b64() {
     BASEPATH=$1
     MAXDEPTH=$2
+    TMPBASE=$3
 
     if [ ! -e $BASEPATH ]; then
         echo "ERROR: $BASEPATH does not exist"
         exit 1
     fi
 
-    PATHS=$($BUSYBOX find $BASEPATH -follow -maxdepth $MAXDEPTH)
-    i=0
-    for path in $PATHS; do
-        i=$(expr $i + 1)
-        if [ $i -gt 1 ]; then
-            break;
-        fi
+    cd $TMPBASE
+    TMP_FOLDER=$($BUSYBOX realpath $($BUSYBOX mktemp -d XXXXXX))
+
+    # 'tar' doesn't work as expected on debugfs, so copy the tree first to
+    # workaround the issue
+    cd $BASEPATH
+    for CUR_FILE in $($BUSYBOX find . -follow -type f -maxdepth $MAXDEPTH); do
+        $BUSYBOX cp --parents $CUR_FILE $TMP_FOLDER/ 2> /dev/null
     done
-    if [ $i -gt 1 ]; then
-        $BUSYBOX grep -s '' $PATHS
-    fi
+
+    cd $TMP_FOLDER
+    $BUSYBOX tar cz * | $BUSYBOX base64
+
+    # Clean-up the tmp folder since we won't need it any more
+    cd $TMPBASE
+    rm -rf $TMP_FOLDER
 }
 
 get_linux_system_id() {
@@ -334,8 +340,8 @@ ftrace_get_function_stats)
 hotplug_online_all)
 	hotplug_online_all
     ;;
-read_tree_values)
-	read_tree_values $*
+read_tree_tgz_b64)
+	read_tree_tgz_b64 $*
     ;;
 get_linux_system_id)
 	get_linux_system_id $*


### PR DESCRIPTION
target.read_tree_values_flat() uses shutil to list the files and their
content using the find command. It expects the command output to have a
'/path/to/file:value' format, and splits it on the first occurence of
':' in the string, hence creating a ['/path/to/file', 'value'] vector.

However, whenever one of the directories has ':' in its name, this
simple procedure fails to split the string at the right place. For
example, using shutil's read_tree_values on the debugfs folders of
the PM_OPP subsystem will return:

  $ ./shutils read_tree_values /sys/kernel/debug/opp/cpu0/opp\:450000000 1
  /sys/kernel/debug/opp/cpu0/opp:450000000/clock_latency_ns:0
  /sys/kernel/debug/opp/cpu0/opp:450000000/rate_hz:450000000
  /sys/kernel/debug/opp/cpu0/opp:450000000/performance_state:0
  /sys/kernel/debug/opp/cpu0/opp:450000000/suspend:N
  /sys/kernel/debug/opp/cpu0/opp:450000000/turbo:N
  /sys/kernel/debug/opp/cpu0/opp:450000000/dynamic:Y
  /sys/kernel/debug/opp/cpu0/opp:450000000/available:Y

Splitting this output on the first occurence of ':' leads
target.read_tree_values() to see '/sys/kernel/debug/opp/cpu0/opp' as a
file with values such as '450000000/clock_latency_ns:0'. This is
obviously incorrect.

In order to fix this, try to split each string on all occurences of ':'
until this matches an existing file on the target.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>