### PR TITLE
shutils: Fix read_tree_tgz_b64 on empty folder

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -276,7 +276,7 @@ read_tree_tgz_b64() {
     done
 
     cd $TMP_FOLDER
-    $BUSYBOX tar cz * | $BUSYBOX base64
+    $BUSYBOX tar cz * 2>/dev/null | $BUSYBOX base64
 
     # Clean-up the tmp folder since we won't need it any more
     cd $TMPBASE


### PR DESCRIPTION
Hide tar stderr output, so it does not get mixed with the base64 stream
in case the folder we are tarring is empty.