### PR TITLE
target/TypedKernelConfig: Fix converting to string method

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1856,7 +1856,7 @@ class TypedKernelConfig(Mapping):
         elif isinstance(val, KernelConfigTristate):
             return val.value
         elif isinstance(val, basestring):
-            return '"{}"'.format(val)
+            return '"{}"'.format(val.strip('"'))
         else:
             return str(val)
 


### PR DESCRIPTION
Some strings already quoted and therefore result in being quoted twice.
Strip off existing quotes before quoting the value to prevent this.