### PR TITLE
target/kernelconfig: Add alias for itteritems

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1999,6 +1999,8 @@ class KernelConfig(object):
         for k, v in self.typed_config.items():
             yield (k, self.typed_config._val_to_str(v))
 
+    items = iteritems
+
     def get(self, name, strict=False):
         if strict:
             val = self.typed_config[name]


### PR DESCRIPTION
Add an 'items' alias for itteritems to avoid confusion when iterating in
different versions of Python.