### PR TITLE
acmecape: Fix buffer_size use with pipes.quote()

### DIFF
--- a/devlib/instrument/acmecape.py
+++ b/devlib/instrument/acmecape.py
@@ -87,7 +87,8 @@ class AcmeCapeInstrument(Instrument):
         params = dict(
             iio_capture=self.iio_capture,
             host=self.host,
-            buffer_size=self.buffer_size,
+            # This must be a string for quote()
+            buffer_size=str(self.buffer_size),
             iio_device=self.iio_device,
             outfile=self.raw_data_file
         )


### PR DESCRIPTION
pipes.quote() doesn't like integers:

```
>>> from pipes import quote
>>> quote(42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.5/shlex.py", line 282, in quote
    if _find_unsafe(s) is None:
TypeError: expected string or bytes-like object
```

Convert buffer_size to str when quoting it