### PR TITLE
target/HexInt: Fix to inherit from long instead of int.

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1792,7 +1792,7 @@ class KernelVersion(object):
     __repr__ = __str__
 
 
-class HexInt(int):
+class HexInt(long):
     """
     Subclass of :class:`int` that uses hexadecimal formatting by default.
     """
@@ -1805,7 +1805,7 @@ class HexInt(int):
             return super_new(cls, val, base=base)
 
     def __str__(self):
-        return hex(self)
+        return hex(self).strip('L')
 
 
 class KernelConfigTristate(Enum):


### PR DESCRIPTION
When using Python 2.7 `int`s have a maximum size which can be exceeded
when attempting to convert the hex representation back. Change `HexInt` to
be a `long` instead to avoid this issue.