### PR TITLE
target: Fix missing import for Python3

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -30,6 +30,7 @@ import xml.dom.minidom
 import copy
 from collections import namedtuple, defaultdict
 from pipes import quote
+from past.builtins import long
 from past.types import basestring
 from numbers import Number
 try:


### PR DESCRIPTION
The `long` type is no longer present in Python3 so import it from
`past.builtins` for compatibility.