### PR TITLE
devlib/sched: Change order of CPU capacity algorithms

### DIFF
--- a/devlib/module/sched.py
+++ b/devlib/module/sched.py
@@ -440,10 +440,10 @@ class SchedModule(Module):
         sd_info = self.get_sd_info()
 
         for cpu in cpus:
-            if self.has_em(cpu, sd_info.cpus[cpu]):
-                capacities[cpu] = self.get_em_capacity(cpu, sd_info.cpus[cpu])
-            elif self.has_dmips_capacity(cpu):
+            if self.has_dmips_capacity(cpu):
                 capacities[cpu] = self.get_dmips_capacity(cpu)
+            elif self.has_em(cpu, sd_info.cpus[cpu]):
+                capacities[cpu] = self.get_em_capacity(cpu, sd_info.cpus[cpu])
             else:
                 if default != None:
                     capacities[cpu] = default


### PR DESCRIPTION
There are two ways we can load CPU capacity. Up until 4.14, supported
kernels did not have the /sys/devices/system/cpu/cpuX/cpu_capacity file
and the only way to read cpu capacity was by grepping the EM from
procfs sched_domain output. After 4.14, that route still exists but is
complicated due to a change in the format once support for
frequency-power models was merged.

In order to avoid rewriting the procfs EM grepping code, lets switch the
order of algorithms we try to use when loading CPU capacity. All newer
kernels provide the dedicated sysfs node and all kernels which do not
have this node use the old format for the EM in sched_domain output.

Signed-off-by: Chris Redpath <chris.redpath@arm.com>