### PR TITLE
host: expect shell syntax inside LocalConnection.execute

### DIFF
--- a/devlib/host.py
+++ b/devlib/host.py
@@ -71,7 +71,7 @@ class LocalConnection(object):
             if self.unrooted:
                 raise TargetStableError('unrooted')
             password = self._get_password()
-            command = 'echo {} | sudo -S '.format(quote(password)) + command
+            command = 'echo {} | sudo -S -- sh -c '.format(quote(password)) + quote(command)
         ignore = None if check_exit_code else 'all'
         try:
             return check_output(command, shell=True, timeout=timeout, ignore=ignore)[0]


### PR DESCRIPTION
When using sudo with LocalConnection, execute the input command via 'sh
-c' to ensure any shell syntax within the command is handled properly.

Fixes https://github.com/ARM-software/devlib/issues/374