### PR TITLE
Exit context manager

### DIFF
--- a/doc/target.rst
+++ b/doc/target.rst
@@ -346,6 +346,18 @@ Target
        some sysfs entries silently failing to set the written value without
        returning an error code.
 
+.. method:: Target.revertable_write_value(path, value [, verify])
+
+   Same as :meth:`Target.write_value`, but as a context manager that will write
+   back the previous value on exit.
+
+.. method:: Target.batch_revertable_write_value(kwargs_list)
+
+   Calls :meth:`Target.revertable_write_value` with all the keyword arguments
+   dictionary given in the list. This is a convenience method to update
+   multiple files at once, leaving them in their original state on exit. If one
+   write fails, all the already-performed writes will be reverted as well.
+
 .. method:: Target.read_tree_values(path, depth=1, dictcls=dict, [, tar [, decode_unicode [, strip_null_char ]]]):
 
    Read values of all sysfs (or similar) file nodes under ``path``, traversing

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ params = dict(
         'wrapt',  # Basic for construction of decorator functions
         'future', # Python 2-3 compatibility
         'enum34;python_version<"3.4"', # Enums for Python < 3.4
+        'contextlib2;python_version<"3.0"', # Python 3 contextlib backport for Python 2
         'numpy<=1.16.4; python_version<"3"',
         'numpy; python_version>="3"',
         'pandas<=0.24.2; python_version<"3"',


### PR DESCRIPTION
Allow reverting a write to path by using `Target.write_value` as returning a context manager. This is useful to have more guarantees that the target is left in a clean state after the code has executed, even if some exceptions were raised (including user interruptions with `KeyboardInterrupt`).

This is 100% backward compatible, as `undo=False` by default.