### PR TITLE
Improve adb_shell and move to 'su -c'

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -431,7 +431,7 @@ def adb_shell(device, command, timeout=None, check_exit_code=False,
     if device is not None:
         parts += ['-s', device]
     parts += ['shell',
-              command if not as_root else 'echo {} | su'.format(quote(command))]
+              command if not as_root else 'su -c {}'.format(quote(command))]
 
     logger.debug(' '.join(quote(part) for part in parts))
     # On older combinations of ADB/Android versions, the adb host command always


### PR DESCRIPTION
Slight rework of `adb_shell` to improve readability and stability but, most importantly, to address #386.

Please note that this requires modern Py3 and should be merged post-WA3.1 (preferred) or could be modified to be Py2.7-compatible.