### PR TITLE
Add generic perf trace instrument

### DIFF
--- a/devlib/trace/perf.py
+++ b/devlib/trace/perf.py
@@ -46,12 +46,6 @@ class PerfCommandDict(collections.OrderedDict):
             if 'stat'in parameters['command']:
                 self._stat_command_labels.add(label)
 
-    def stat_commands(self):
-        return {label: self[label] for label in self._stat_command_labels}
-
-    def as_strings(self):
-        return {label: str(cmd) for label, cmd in self.items()}
-
 
 class PerfCollector(TraceCollector):
     """Perf is a Linux profiling tool based on performance counters.

--- a/devlib/trace/perf.py
+++ b/devlib/trace/perf.py
@@ -109,17 +109,21 @@ class PerfCollector(TraceCollector):
         for label, command in self.post_commands.items():
             self.execute(str(command), label)
 
+    def _target_runnable_command(self, command, label=None):
+        cmd = '{} {}'.format(self.binary, command)
+        if label is None:
+            return cmd
+        directory = quote(self.working_directory(label))
+        cwd = 'mkdir -p {0} && cd {0}'.format(directory)
+        return '{cwd} && {cmd}'.format(cwd=cwd, cmd=cmd)
+
     def kick_off(self, command, label=None):
-        directory = quote(self.working_directory(label or 'default'))
-        return self.target.kick_off('mkdir -p {0} && cd {0} && {1} {2}'
-                                    .format(directory, self.binary, command),
-                                    as_root=self.target.is_rooted)
+        cmd = self._target_runnable_command(command, label)
+        return self.target.kick_off(cmd, as_root=self.target.is_rooted)
 
     def execute(self, command, label=None):
-        directory = quote(self.working_directory(label or 'default'))
-        return self.target.execute('mkdir -p {0} && cd {0} && {1} {2}'
-                                   .format(directory, self.binary, command),
-                                   as_root=self.target.is_rooted)
+        cmd = self._target_runnable_command(command, label)
+        return self.target.execute(cmd, as_root=self.target.is_rooted)
 
     def working_directory(self, label=None):
         wdir = self.target.path.join(self.target.working_directory,

--- a/devlib/utils/cli.py
+++ b/devlib/utils/cli.py
@@ -17,34 +17,73 @@ import collections
 import itertools
 import shlex
 
-class Command(dict):
+
+class Command(dict):  # inherit from dict for JSON serializability
     """Provides an abstraction for manipulating CLI commands
+
+    The expected format of the abstracted command is as follows::
+
+        <command> <flags> <kwflags> <options> <end_of_options> <args>
+
+    where
+
+        - `<command>` is the command name or path (used as-is);
+        - `<flags>` are space-separated flags with a leading `-` (single
+          character flag) or `--` (multiple characters);
+        - `<kwflags>` are space-separated key-value flag pairs with a leading
+          `-` (single character flag) or `--` (multiple characters), a
+          key-value separator (typically `=`) and, if required, a CLI-compliant
+          escaped value;
+        - `<options>` are space-separated options (used as-is);
+        - `<end_of_options>` is a character sequence understood by `<command>`
+          as meaning the end of the options (typically `--`);
+        - `<args>` are the arguments to the command and could potentially
+          themselves be a valid command (_e.g._ POSIX `time`);
+
+    If allowed by the CLI, redirecting the output streams of the command
+    (potentially between themselves) may be done through this abstraciton.
     """
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-few-public-methods
     def __init__(self, command, flags=None, kwflags=None, kwflags_sep=' ',
-                 kwflags_join=',', options=None, end_of_options=None, args=None,
-                 stdout=None, stderr=None):
+                 kwflags_join=',', options=None, end_of_options=None,
+                 args=None, stdout=None, stderr=None):
         """
-        NB: if ``None`` in ``flags``, ``kwflags``, ``options``, replace with ``''``
-        empty flags are ignored
-        empty kwflag values are kept but striped
-        NB: caller responsible for escaping args as a single string
-        """ #TODO
+        Parameters:
+            command    command name or path
+            flags      ``str`` or list of ``str`` without the leading `-`/`--`.
+                       Flags that evaluate as falsy are ignored;
+            kwflags    mapping giving the key-value pairs. The key and value of
+                       the pair are separated by a `kwflags_sep`. If the value
+                       is a list, it is joined with `kwflags_join`. If a value
+                       evaluates as falsy, it is replaced by the empty string;
+            kwflags_sep   Key-value separator for `kwflags`;
+            kwflags_join  Separator for lists of values in `kwflags`;
+            options    same as `flags` but nothing is prepended to the options;
+            args       ``str`` or mapping holding keys which are valid
+                       arguments to this constructor, for recursive
+                       instantiation;
+            stdout     file for redirection of ``stdout``. This is passed to
+                       the CLI so non-file expressions may be used (*e.g.*
+                       `&2`);
+            stderr     file for redirection of ``stderr``. This is passed to
+                       the CLI so non-file expressions may be used (*e.g.*
+                       `&1`);
+        """
         # pylint: disable=too-many-arguments
-        these = lambda x: (x if isinstance(x, collections.abc.Iterable)
-                           and not isinstance(x, str) else [x])
-
-        self.command = shlex.split(command)
-        self.flags = map(str, filter(None, these(flags)))
+        # pylint: disable=super-init-not-called
+        self.command = ' '.join(shlex.split(command))
+        self.flags = map(str, filter(None, self._these(flags)))
         self.kwflags_sep = kwflags_sep
         self.kwflags_join = kwflags_join
-        self.kwflags = {} if kwflags is None else {
-            key: ['' if x is None else str(x) for x in these(values)]
-            for key, values in kwflags.items()
-        }
+        self.kwflags = {}
+        if kwflags is not None:
+            for k in kwflags:
+                v = ['' if x is None else str(x)
+                     for x in self._these(kwflags[k])]
+                self.kwflags[k] = v[0] if len(v) == 1 else v
         self.options = [] if options is None else [
-            '' if x is None else str(x) for x in these(options)]
+            '' if x is None else str(x) for x in self._these(options)]
         if end_of_options:
             self.options.append(str(end_of_options).strip())
         if isinstance(args, collections.Mapping):
@@ -55,14 +94,12 @@ class Command(dict):
         self.stderr = stderr
 
     def __str__(self):
-        filepipe = lambda f: (f if isinstance(f, str) and f.startswith('&')
-                              else shlex.quote(f))
         quoted = itertools.chain(
-            self.command,
+            shlex.split(self.command),
             map(self._flagged, self.flags),
             ('{}{}{}'.format(self._flagged(k),
                              self.kwflags_sep,
-                             self.kwflags_join.join(v))
+                             self.kwflags_join.join(self._these(v)))
              for k, v in self.kwflags.items()),
             self.options
         )
@@ -70,14 +107,27 @@ class Command(dict):
         if self.args:
             words.append(str(self.args))
         if self.stdout:
-            words.append('1>{}'.format(filepipe(self.stdout)))
+            words.append('1>{}'.format(self._filepipe(self.stdout)))
         if self.stderr:
-            words.append('2>{}'.format(filepipe(self.stderr)))
+            words.append('2>{}'.format(self._filepipe(self.stderr)))
         return ' '.join(words)
 
     def __getitem__(self, key):
         return self.__dict__[key]
 
+    @staticmethod
+    def _these(x):
+        if isinstance(x, str) or not isinstance(x, collections.abc.Iterable):
+            return [x]
+        return x
+
+    @staticmethod
+    def _filepipe(f):
+        if isinstance(f, str) and f.startswith('&'):
+            return f
+        return shlex.quote(f)
+
     @classmethod
     def _flagged(cls, flag):
-        return '{}{}'.format('--' if len(flag) > 1 else '-', str(flag).strip())
+        flag = str(flag).strip()
+        return '{}{}'.format('--' if len(flag) > 1 else '-', flag)

--- a/devlib/utils/cli.py
+++ b/devlib/utils/cli.py
@@ -17,7 +17,7 @@ import collections
 import itertools
 import shlex
 
-class Command:
+class Command(dict):
     """Provides an abstraction for manipulating CLI commands
     """
     # pylint: disable=too-many-instance-attributes
@@ -74,6 +74,9 @@ class Command:
         if self.stderr:
             words.append('2>{}'.format(filepipe(self.stderr)))
         return ' '.join(words)
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
 
     @classmethod
     def _flagged(cls, flag):

--- a/devlib/utils/cli.py
+++ b/devlib/utils/cli.py
@@ -1,0 +1,80 @@
+#    Copyright 2019 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import collections
+import itertools
+import shlex
+
+class Command:
+    """Provides an abstraction for manipulating CLI commands
+    """
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-few-public-methods
+    def __init__(self, command, flags=None, kwflags=None, kwflags_sep=' ',
+                 kwflags_join=',', options=None, end_of_options=None, args=None,
+                 stdout=None, stderr=None):
+        """
+        NB: if ``None`` in ``flags``, ``kwflags``, ``options``, replace with ``''``
+        empty flags are ignored
+        empty kwflag values are kept but striped
+        NB: caller responsible for escaping args as a single string
+        """ #TODO
+        # pylint: disable=too-many-arguments
+        these = lambda x: (x if isinstance(x, collections.abc.Iterable)
+                           and not isinstance(x, str) else [x])
+
+        self.command = shlex.split(command)
+        self.flags = map(str, filter(None, these(flags)))
+        self.kwflags_sep = kwflags_sep
+        self.kwflags_join = kwflags_join
+        self.kwflags = {} if kwflags is None else {
+            key: ['' if x is None else str(x) for x in these(values)]
+            for key, values in kwflags.items()
+        }
+        self.options = [] if options is None else [
+            '' if x is None else str(x) for x in these(options)]
+        if end_of_options:
+            self.options.append(str(end_of_options).strip())
+        if isinstance(args, collections.Mapping):
+            self.args = Command(**args)
+        else:
+            self.args = None if args is None else str(args)
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __str__(self):
+        filepipe = lambda f: (f if isinstance(f, str) and f.startswith('&')
+                              else shlex.quote(f))
+        quoted = itertools.chain(
+            self.command,
+            map(self._flagged, self.flags),
+            ('{}{}{}'.format(self._flagged(k),
+                             self.kwflags_sep,
+                             self.kwflags_join.join(v))
+             for k, v in self.kwflags.items()),
+            self.options
+        )
+        words = [shlex.quote(word) for word in quoted]
+        if self.args:
+            words.append(str(self.args))
+        if self.stdout:
+            words.append('1>{}'.format(filepipe(self.stdout)))
+        if self.stderr:
+            words.append('2>{}'.format(filepipe(self.stderr)))
+        return ' '.join(words)
+
+    @classmethod
+    def _flagged(cls, flag):
+        return '{}{}'.format('--' if len(flag) > 1 else '-', str(flag).strip())


### PR DESCRIPTION
As discussed in #382, this PR modifies the `perf` trace instrument so that it accepts any `perf` command. It implements the back-end of ARM-software/workload-automation#979 and requires fix #387 to avoid #386. It is arguably simple as it receives the commands to run as strings (prepending the path to `perf`) and runs them "at the right time".

Based on the  subcommands `perf` currently has, it looks like these can be placed in 3 categories:
- The "measuring" commands (`commands`): used to trace/measure some system properties (`stat`, `record`, `mem`, `sched`, `kmem`, `kvm`, `c2c`, ...);
- The "reporting" commands (`post_commands`): used to process a trace file from a "measuring" command (`report`, `script`, `timechart`, `annotate, `c2c report`, ...);
- The "information" and "configuration" commands (`pre_commands`): used to configure the system or get general information (`list`, `config`, `buildid-list`, `help`, ...)

Therefore, we take 3 dictionaries of commands that are run in order (`pre_`, then `commands`, then `post_`) in accord with these definitions. I'm still not perfectly sure about "when" in the WA/devlib process these are to be run, though. Please check that.

The reason why we have dictionaries for commands (instead of lists) is that the keys can act as a label which seemed to be a desired feature of the previous implementation. As we have multiple dictionaries, a same label can appear multiple times (_i.e._ as a key in more than a single dictionary). In that case, it makes sense to "group" these commands in their own "execution lane" _e.g._ a `record` and its corresponding `report`. Maybe, these labels could be used as directory names on the target and then on the host, once having been extracted(?) For example, commands within the same label would "see" the same files (as they would be in the same subfolder) while commands with different labels wouldn't and would therefore be able to re-use the same filenames. A similar approach with respect to the filename would be to prepend/inject/append the label to the filename.

The `Command` class is implemented to be used by the corresponding WA `perf` instrument when generating the `perf` commands passed to the devlib `PerfCollector`. I thought it would make sense to have that class in devlib instead of WA. See the front-end PR for a description of the constructor parameters.

The `get_trace` hasn't been implemented yet. If we're going with a function that extracts one `outfile` at a time, the caller (WA) will have to keep track of which files are generated by which commands (_e.g._ the `stdout`, `stderr`, `perf.data`, ...) which is hard to do. Another approach might be to extract a pull a complete folder from the target (_e.g._ `/sdcard/devlib-target/perf`) in which `perf` would have run. This decision is also influenced by whether labels are used as subfolders or not.

Parsing of the output(s) is the responsibility of WA and won't be done here.

Please note that the proposed implementation is *not* an in-place replacement for the previous implementation of `PerfCollector`. Therefore, the previous implementation has been moved to `perf_stat`, should be deprecated (not sure what the best way to do that is) and should eventually be removed.

### TODO:

- [x] Check the location of execution of `pre_`, `commands`, `post_` in the WA/devlib flow;
- [x] ~~Deprecate `PerfStatCollector`~~
- [x] Decide how labels are used on the device
- [x] Document `PerfCollector` (what is expected?)
- [x] Trace extraction (per file? ...)