### PR TITLE
target: Ensure we use installed binaries

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -385,6 +385,9 @@ class Target(object):
 
     def execute(self, command, timeout=None, check_exit_code=True,
                 as_root=False, strip_colors=True, will_succeed=False):
+        # Ensure to use deployed command when availables
+        if self.executables_directory:
+            command = "PATH={}:$PATH && {}".format(self.executables_directory, command)
         return self.conn.execute(command, timeout=timeout,
                 check_exit_code=check_exit_code, as_root=as_root,
                 strip_colors=strip_colors, will_succeed=will_succeed)


### PR DESCRIPTION
Apart from busybox, devlib itself makes use of other system provided binaries.
For example, the DmesgCollector module uses the system provided dmesg.
In cases the system provided binary does not support some of the features
required by devlib, we currently just fails with an error.

For the user it is still possible to deploy a custom/updated version of a
required binary via the Target::install API. However, that binary is not
automatically considered by devlib.

Let's ensure that all Target::execute commands use a PATH which gives priority
to devlib installed binaries.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>