### PR TITLE
devlib: Re-export DmesgCollector in devlib package

### DIFF
--- a/devlib/__init__.py
+++ b/devlib/__init__.py
@@ -48,6 +48,7 @@ from devlib.derived.fps import DerivedGfxInfoStats, DerivedSurfaceFlingerStats
 from devlib.trace.ftrace import FtraceCollector
 from devlib.trace.perf import PerfCollector
 from devlib.trace.serial_trace import SerialTraceCollector
+from devlib.trace.dmesg import DmesgCollector
 
 from devlib.host import LocalConnection
 from devlib.utils.android import AdbConnection


### PR DESCRIPTION
Allow using 'import devlib.DmesgCollector', just like
devlib.FtraceCollector.

note: not sure if this kind of import is just there for backward compatibility, or is expected to be used for new code as well.