### PR TITLE
setup.py: Set maximum package version for python2.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,10 @@ params = dict(
         'wrapt',  # Basic for construction of decorator functions
         'future', # Python 2-3 compatibility
         'enum34;python_version<"3.4"', # Enums for Python < 3.4
-        'pandas',
-        'numpy',
+        'numpy<=1.16.4; python_version<"3"',
+        'numpy; python_version>="3"',
+        'pandas<=0.24.2; python_version<"3"',
+        'pandas; python_version>"3"',
     ],
     extras_require={
         'daq': ['daqpower'],


### PR DESCRIPTION
In the latest versions of panadas and numpy python2.7 support has been
dropped therefore restrict the maximum version of these packages.