### PR TITLE
module/cpuidle: Add fallback for reading governor

### DIFF
--- a/devlib/module/cpuidle.py
+++ b/devlib/module/cpuidle.py
@@ -173,4 +173,7 @@ class Cpuidle(Module):
         return self.target.read_value(self.target.path.join(self.root_path, 'current_driver'))
 
     def get_governor(self):
-        return self.target.read_value(self.target.path.join(self.root_path, 'current_governor_ro'))
+        path = self.target.path.join(self.root_path, 'current_governor_ro')
+        if not self.target.path.exist(path):
+            path = self.target.path.join(self.root_path, 'current_governor')
+        return self.target.read_value(path)


### PR DESCRIPTION
As per #407 if the kernel is compiled with the ability to switch cpuidle
governors via sysfs `current_governor_ro` is replaced with
`current_governor` so check if the intial path exists before reading.