### PR TITLE
trace/systrace: make start() return when tracing has started

### DIFF
--- a/devlib/trace/systrace.py
+++ b/devlib/trace/systrace.py
@@ -107,7 +107,7 @@ class SystraceCollector(TraceCollector):
         self._tmpfile = NamedTemporaryFile()
 
         # pylint: disable=attribute-defined-outside-init
-        self.systrace_cmd = '{} -o {} -e {}'.format(
+        self.systrace_cmd = 'python2 -u {} -o {} -e {}'.format(
             self.systrace_binary,
             self._tmpfile.name,
             self.target.adb_name
@@ -137,9 +137,11 @@ class SystraceCollector(TraceCollector):
         self._systrace_process = subprocess.Popen(
             self.systrace_cmd,
             stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
             shell=True,
             universal_newlines=True
         )
+        self._systrace_process.stdout.read(1)
 
     def stop(self):
         if not self._systrace_process:


### PR DESCRIPTION
In `devlib.trace.SystraceCollector`, `start()` returns after executing
`subprocess.Popen()` for systrace. That doesn't mean that systrace is
running though, the function can return even before systrace has had a
chance to execute anything. Therefore, when you run the command
you want to trace, systrace will miss the first seconds of the
execution.

Run systrace with `-u` to unbuffer its stdin and wait for it to print
"Starting tracing (stop with enter)" before returning.

Fixes #403