### PR TITLE
Allow for restarting adb as root upon connection. 

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -113,15 +113,15 @@ class Target(object):
         return self._connected_as_root
 
     @property
-    @memoized
     def is_rooted(self):
-        if self.connected_as_root:
-            return True
-        try:
-            self.execute('ls /', timeout=5, as_root=True)
-            return True
-        except (TargetStableError, TimeoutError):
-            return False
+        if self._is_rooted is None:
+            try:
+                self.execute('ls /', timeout=5, as_root=True)
+                self._is_rooted = True
+            except (TargetStableError, TimeoutError):
+                self._is_rooted = False
+
+        return self._is_rooted or self.connected_as_root
 
     @property
     @memoized
@@ -214,6 +214,7 @@ class Target(object):
                  is_container=False
                  ):
         self._connected_as_root = None
+        self._is_rooted = None
         self.connection_settings = connection_settings or {}
         # Set self.platform: either it's given directly (by platform argument)
         # or it's given in the connection_settings argument

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1481,14 +1481,11 @@ class AndroidTarget(Target):
         adb_command(self.adb_name, 'reboot-bootloader', timeout)
 
     def adb_root(self, enable=True, force=False):
-        if enable:
-            if self._connected_as_root and not force:
-                return
-            adb_command(self.adb_name, 'root', timeout=30)
-            self._connected_as_root = True
+        if not isinstance(self.conn, AdbConnection):
+            raise TargetStableError('Cannot enable adb root without adb connection')
+        if enable and self.connected_as_root and not force:
             return
-        adb_command(self.adb_name, 'unroot', timeout=30)
-        self._connected_as_root = False
+        self.conn.adb_root(self.adb_name, enable=enable)
 
     def is_screen_on(self):
         output = self.execute('dumpsys power')

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -107,10 +107,7 @@ class Target(object):
 
     @property
     def connected_as_root(self):
-        if self._connected_as_root is None:
-            result = self.execute('id')
-            self._connected_as_root = 'uid=0(' in result
-        return self._connected_as_root
+        return self.conn and self.conn.connected_as_root
 
     @property
     def is_rooted(self):
@@ -213,7 +210,6 @@ class Target(object):
                  conn_cls=None,
                  is_container=False
                  ):
-        self._connected_as_root = None
         self._is_rooted = None
         self.connection_settings = connection_settings or {}
         # Set self.platform: either it's given directly (by platform argument)
@@ -323,7 +319,7 @@ class Target(object):
             timeout = max(timeout - reset_delay, 10)
         if self.has('boot'):
             self.boot()  # pylint: disable=no-member
-        self._connected_as_root = None
+        self.conn.connected_as_root = None
         if connect:
             self.connect(timeout=timeout)
 
@@ -497,7 +493,7 @@ class Target(object):
         except (DevlibTransientError, subprocess.CalledProcessError):
             # on some targets "reboot" doesn't return gracefully
             pass
-        self._connected_as_root = None
+        self.conn.connected_as_root = None
 
     def check_responsive(self, explode=True):
         try:
@@ -1169,7 +1165,7 @@ class AndroidTarget(Target):
         except (DevlibTransientError, subprocess.CalledProcessError):
             # on some targets "reboot" doesn't return gracefully
             pass
-        self._connected_as_root = None
+        self.conn.connected_as_root = None
 
     def wait_boot_complete(self, timeout=10):
         start = time.time()

--- a/doc/connection.rst
+++ b/doc/connection.rst
@@ -100,7 +100,7 @@ class that implements the following methods.
 Connection Types
 ----------------
 
-.. class:: AdbConnection(device=None, timeout=None)
+.. class:: AdbConnection(device=None, timeout=None, adb_server=None, adb_as_root=False)
 
     A connection to an android device via ``adb`` (Android Debug Bridge).
     ``adb`` is part of the Android SDK (though stand-alone versions are also
@@ -113,10 +113,13 @@ Connection Types
     :param timeout: Connection timeout in seconds. If a connection to the device
                     is not established within this period, :class:`HostError`
                     is raised.
+    :param adb_server: Allows specifying the address of the adb server to use.
+    :param adb_as_root: Specify whether the adb server should be restarted in root mode.
 
 
 .. class:: SshConnection(host, username, password=None, keyfile=None, port=None,\
-                         timeout=None, password_prompt=None)
+                         timeout=None, password_prompt=None, \
+                         sudo_cmd="sudo -- sh -c {}")
 
     A connection to a device on the network over SSH.
 
@@ -141,6 +144,7 @@ Connection Types
     :param password_prompt: A string with the password prompt used by
                             ``sshpass``. Set this if your version of ``sshpass``
                             uses something other than ``"[sudo] password"``.
+    :param sudo_cmd: Specify the format of the command used to grant sudo access.
 
 
 .. class:: TelnetConnection(host, username, password=None, port=None,\


### PR DESCRIPTION
As per https://github.com/ARM-software/devlib/issues/406 currently in order to enable adbd as root, a connection to the target already needs to exist however there are use case that we want to perform initialising as root as well.

- Add a utility function to restarted adbd in rooted and unrooted mode.
- Add the `adb_as_root` connection parameter to `AdbConnection`.

Note: This will restart adbd as root before attempting to connect to the target and will also restart adbd unrooted upon the last disconnection from the target.  