### PR TITLE
target: android: Run adb root early

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1190,6 +1190,10 @@ class AndroidTarget(Target):
             # indefinitely when making calls to the device. To avoid this,
             # always disconnect first.
             adb_disconnect(device)
+
+        if self.connection_settings.get('username') == 'root':
+            self.adb_root(device=self.connection_settings.get('device', ''))
+
         super(AndroidTarget, self).connect(timeout=timeout, check_boot_completed=check_boot_completed)
 
     def kick_off(self, command, as_root=None):
@@ -1483,14 +1487,16 @@ class AndroidTarget(Target):
     def adb_reboot_bootloader(self, timeout=30):
         adb_command(self.adb_name, 'reboot-bootloader', timeout)
 
-    def adb_root(self, enable=True, force=False):
+    def adb_root(self, enable=True, force=False, device=None):
+        adb_name = device if device is not None else self.adb_name
+
         if enable:
             if self._connected_as_root and not force:
                 return
-            adb_command(self.adb_name, 'root', timeout=30)
+            adb_command(adb_name, 'root', timeout=30)
             self._connected_as_root = True
             return
-        adb_command(self.adb_name, 'unroot', timeout=30)
+        adb_command(adb_name, 'unroot', timeout=30)
         self._connected_as_root = False
 
     def is_screen_on(self):

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -246,7 +246,7 @@ class AdbConnection(object):
         return self.device
 
     # pylint: disable=unused-argument
-    def __init__(self, device=None, timeout=None, platform=None, adb_server=None):
+    def __init__(self, device=None, timeout=None, platform=None, adb_server=None, username=None):
         self.timeout = timeout if timeout is not None else self.default_timeout
         if device is None:
             device = adb_get_device(timeout=timeout, adb_server=adb_server)


### PR DESCRIPTION
Run adb root in AndroidTarget before calling super().connect() when username is
"root" since some devlib modules will require root permissions to initialize.

This introduces a "username" connection setting for Android that is mostly
ignored, but taken as a hint to run adb_root().

Fix #406 