### PR TITLE
module/cpufreq: Make use_governor() affect only online CPUs

### DIFF
--- a/devlib/module/cpufreq.py
+++ b/devlib/module/cpufreq.py
@@ -111,7 +111,7 @@ class CpufreqModule(Module):
         :Keyword Arguments: Governor tunables, See :meth:`set_governor_tunables`
         """
         if not cpus:
-            cpus = range(self.target.number_of_cpus)
+            cpus = self.target.list_online_cpus()
 
         # Setting a governor & tunables for a cpu will set them for all cpus
         # in the same clock domain, so only manipulating one cpu per domain


### PR DESCRIPTION
Turns out you can't change cpufreq attributes on an offlined
CPU (no big surprise!), so use_governor() will fail if a whole
frequency domain has been hotplugged out.

Change the default behaviour to only target online CPUs.