### PR TITLE
trace: dmesg: Ignore empty lines

### DIFF
--- a/devlib/trace/dmesg.py
+++ b/devlib/trace/dmesg.py
@@ -166,6 +166,7 @@ class DmesgCollector(TraceCollector):
             return [
                 KernelLogEntry.from_str(line)
                 for line in dmesg_out.splitlines()
+                if line.strip()
             ]
 
     def reset(self):
@@ -195,4 +196,3 @@ class DmesgCollector(TraceCollector):
     def get_trace(self, outfile):
         with open(outfile, 'wt') as f:
             f.write(self.dmesg_out + '\n')
-


### PR DESCRIPTION
dmesg output seems to sometimes include an empty line. Ignore them, so we don't
fail to match with the regexes.