### PR TITLE
AndroidTarget: Fix additional paramter to `adb_root`

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1534,7 +1534,7 @@ class AndroidTarget(Target):
             raise TargetStableError('Cannot enable adb root without adb connection')
         if enable and self.connected_as_root and not force:
             return
-        self.conn.adb_root(self.adb_name, enable=enable)
+        self.conn.adb_root(enable=enable)
 
     def is_screen_on(self):
         output = self.execute('dumpsys power')


### PR DESCRIPTION
Remove the target `adb_name` from the call as this method is an instance
method.

Fixes: https://github.com/ARM-software/devlib/issues/428