### PR TITLE
instruments: Add teardown method to clean up tempfiles

### DIFF
--- a/devlib/instrument/acmecape.py
+++ b/devlib/instrument/acmecape.py
@@ -58,12 +58,14 @@ class AcmeCapeInstrument(Instrument):
                  iio_capture=which('iio-capture'),
                  host='baylibre-acme.local',
                  iio_device='iio:device0',
-                 buffer_size=256):
+                 buffer_size=256,
+                 keep_raw=False):
         super(AcmeCapeInstrument, self).__init__(target)
         self.iio_capture = iio_capture
         self.host = host
         self.iio_device = iio_device
         self.buffer_size = buffer_size
+        self.keep_raw = keep_raw
         self.sample_rate_hz = 100
         if self.iio_capture is None:
             raise HostError('Missing iio-capture binary')
@@ -161,5 +163,6 @@ class AcmeCapeInstrument(Instrument):
         return [self.raw_data_file]
 
     def teardown(self):
-        if os.path.isfile(self.raw_data_file):
-            os.remove(self.raw_data_file)
+        if not self.keep_raw:
+            if os.path.isfile(self.raw_data_file):
+                os.remove(self.raw_data_file)

--- a/devlib/instrument/acmecape.py
+++ b/devlib/instrument/acmecape.py
@@ -159,3 +159,7 @@ class AcmeCapeInstrument(Instrument):
 
     def get_raw(self):
         return [self.raw_data_file]
+
+    def teardown(self):
+        if os.path.isfile(self.raw_data_file):
+            os.remove(self.raw_data_file)

--- a/devlib/instrument/arm_energy_probe.py
+++ b/devlib/instrument/arm_energy_probe.py
@@ -71,7 +71,7 @@ class ArmEnergyProbeInstrument(Instrument):
 
     MAX_CHANNELS = 12 # 4 Arm Energy Probes
 
-    def __init__(self, target, config_file='./config-aep', ):
+    def __init__(self, target, config_file='./config-aep', keep_raw=False):
         super(ArmEnergyProbeInstrument, self).__init__(target)
         self.arm_probe = which('arm-probe')
         if self.arm_probe is None:
@@ -80,6 +80,7 @@ class ArmEnergyProbeInstrument(Instrument):
         self.attributes = ['power', 'voltage', 'current']
         self.sample_rate_hz = 10000
         self.config_file = config_file
+        self.keep_raw = keep_raw
 
         self.parser = AepParser()
         #TODO make it generic
@@ -144,5 +145,6 @@ class ArmEnergyProbeInstrument(Instrument):
         return [self.output_file_raw]
 
     def teardown(self):
-        if os.path.isfile(self.output_file_raw):
-            os.remove(self.output_file_raw)
+        if not self.keep_raw:
+            if os.path.isfile(self.output_file_raw):
+                os.remove(self.output_file_raw)

--- a/devlib/instrument/arm_energy_probe.py
+++ b/devlib/instrument/arm_energy_probe.py
@@ -142,3 +142,7 @@ class ArmEnergyProbeInstrument(Instrument):
 
     def get_raw(self):
         return [self.output_file_raw]
+
+    def teardown(self):
+        if os.path.isfile(self.output_file_raw):
+            os.remove(self.output_file_raw)

--- a/devlib/instrument/daq.py
+++ b/devlib/instrument/daq.py
@@ -45,9 +45,11 @@ class DaqInstrument(Instrument):
                  dv_range=0.2,
                  sample_rate_hz=10000,
                  channel_map=(0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23),
+                 keep_raw=False
                  ):
         # pylint: disable=no-member
         super(DaqInstrument, self).__init__(target)
+        self.keep_raw = keep_raw
         self._need_reset = True
         self._raw_files = []
         if execute_command is None:
@@ -155,8 +157,9 @@ class DaqInstrument(Instrument):
 
     def teardown(self):
         self.execute('close')
-        if os.path.isdir(tempdir):
-            shutil.rmtree(tempdir)
+        if not self.keep_raw:
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
 
     def execute(self, command, **kwargs):
         return execute_command(self.server_config, command, **kwargs)

--- a/devlib/instrument/daq.py
+++ b/devlib/instrument/daq.py
@@ -14,6 +14,7 @@
 #
 
 import os
+import shutil
 import tempfile
 from itertools import chain
 
@@ -154,6 +155,8 @@ class DaqInstrument(Instrument):
 
     def teardown(self):
         self.execute('close')
+        if os.path.isdir(tempdir):
+            shutil.rmtree(tempdir)
 
     def execute(self, command, **kwargs):
         return execute_command(self.server_config, command, **kwargs)

--- a/devlib/instrument/energy_probe.py
+++ b/devlib/instrument/energy_probe.py
@@ -34,9 +34,11 @@ class EnergyProbeInstrument(Instrument):
     def __init__(self, target, resistor_values,
                  labels=None,
                  device_entry='/dev/ttyACM0',
+                 keep_raw=False
                  ):
         super(EnergyProbeInstrument, self).__init__(target)
         self.resistor_values = resistor_values
+        self.keep_raw = keep_raw
         if labels is not None:
             self.labels = labels
         else:
@@ -128,5 +130,6 @@ class EnergyProbeInstrument(Instrument):
         return [self.raw_data_file]
 
     def teardown(self):
-        if os.path.isfile(self.raw_data_file):
-            os.remove(self.raw_data_file)
+        if self.keep_raw:
+            if os.path.isfile(self.raw_data_file):
+                os.remove(self.raw_data_file)

--- a/devlib/instrument/energy_probe.py
+++ b/devlib/instrument/energy_probe.py
@@ -126,3 +126,7 @@ class EnergyProbeInstrument(Instrument):
 
     def get_raw(self):
         return [self.raw_data_file]
+
+    def teardown(self):
+        if os.path.isfile(self.raw_data_file):
+            os.remove(self.raw_data_file)

--- a/devlib/instrument/frames.py
+++ b/devlib/instrument/frames.py
@@ -70,6 +70,11 @@ class FramesInstrument(Instrument):
     def _init_channels(self):
         raise NotImplementedError()
 
+    def teardown(self):
+        if not self.keep_raw:
+            if os.path.isfile(self._raw_file):
+                os.remove(self._raw_file)
+
 
 class GfxInfoFramesInstrument(FramesInstrument):
 

--- a/doc/instrumentation.rst
+++ b/doc/instrumentation.rst
@@ -164,7 +164,7 @@ Instrument
 .. method:: Instrument.get_raw()
 
    Returns a list of paths to files containing raw output from the underlying
-   source(s) that is used to produce the data CSV. If now raw output is
+   source(s) that is used to produce the data CSV. If no raw output is
    generated or saved, an empty list will be returned. The format of the
    contents of the raw files is entirely source-dependent.
 
@@ -400,7 +400,7 @@ For reference, the software stack on the host is roughly given by:
 
 Ethernet was the only IIO Interface used and tested during the development of
 this instrument. However,
-`USB seems to be supported<https://gitlab.com/baylibre-acme/ACME/issues/2>`_.
+`USB seems to be supported <https://gitlab.com/baylibre-acme/ACME/issues/2>`_.
 The IIO library also provides "Local" and "XML" connections but these are to be
 used when the IIO devices are directly connected to the host *i.e.* in our
 case, if we were to run Python and devlib on the BBB. These are also untested.

--- a/doc/instrumentation.rst
+++ b/doc/instrumentation.rst
@@ -168,6 +168,17 @@ Instrument
    generated or saved, an empty list will be returned. The format of the
    contents of the raw files is entirely source-dependent.
 
+  .. note:: This method is not guaranteed to return valid filepaths after the
+            :meth:`teardown` method has been invoked as the raw files may have
+            been deleted. Please ensure that copies are created manually
+            prior to calling :meth:`teardown` if the files are to be retained.
+
+.. method:: Instrument.teardown()
+
+   Performs any required clean up of the instrument. This usually includes
+   removing temporary and raw files (if ``keep_raw`` is set to ``False`` on relevant
+   instruments), stopping services etc.
+
 .. attribute:: Instrument.sample_rate_hz
 
    Sample rate of the instrument in Hz. Assumed to be the same for all channels.


### PR DESCRIPTION
Implement the `teardown` method in instruments that utilise tempfiles
which were previously left behind.