### PR TITLE
module/thermal: List directories with as_root=True

### DIFF
--- a/devlib/module/thermal.py
+++ b/devlib/module/thermal.py
@@ -48,7 +48,7 @@ class ThermalZone(object):
         self.path = target.path.join(root, self.name)
         self.trip_points = {}
 
-        for entry in self.target.list_directory(self.path):
+        for entry in self.target.list_directory(self.path, as_root=target.is_rooted):
             re_match = re.match('^trip_point_([0-9]+)_temp', entry)
             if re_match is not None:
                 self.add_trip_point(re_match.group(1))


### PR DESCRIPTION
Listing thermal zones directories in sysfs fails when running as non-root.

Signed-off-by: Douglas RAILLARD <douglas.raillard@arm.com>