### PR TITLE
module/cgroups: Really move all tasks in Controller.move_all_tasks_to()

### DIFF
--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -124,11 +124,10 @@ class Controller(object):
     def move_tasks(self, source, dest, exclude=None):
         if exclude is None:
             exclude = []
-        try:
-            srcg = self._cgroups[source]
-            dstg = self._cgroups[dest]
-        except KeyError as e:
-            raise ValueError('Unknown group: {}'.format(e))
+
+        srcg = self.cgroup(source)
+        dstg = self.cgroup(dest)
+
         self.target._execute_util(  # pylint: disable=protected-access
                     'cgroups_tasks_move {} {} \'{}\''.format(
                     srcg.directory, dstg.directory, exclude),
@@ -169,7 +168,7 @@ class Controller(object):
             self.logger.debug('   excluding tasks which name matches:')
             self.logger.debug('   %s', ', '.join(exclude))
 
-        for cgroup in self._cgroups:
+        for cgroup in self.list_all():
             if cgroup != dest:
                 self.move_tasks(cgroup, dest, grep_filters)
 

--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -158,16 +158,16 @@ class Controller(object):
             raise ValueError('wrong type for "exclude" parameter, '
                              'it must be a str or a list')
 
-        logging.debug('Moving all tasks into %s', dest)
+        self.logger.debug('Moving all tasks into %s', dest)
 
         # Build list of tasks to exclude
         grep_filters = ''
         for comm in exclude:
             grep_filters += '-e {} '.format(comm)
-        logging.debug('   using grep filter: %s', grep_filters)
+        self.logger.debug('   using grep filter: %s', grep_filters)
         if grep_filters != '':
-            logging.debug('   excluding tasks which name matches:')
-            logging.debug('   %s', ', '.join(exclude))
+            self.logger.debug('   excluding tasks which name matches:')
+            self.logger.debug('   %s', ', '.join(exclude))
 
         for cgroup in self._cgroups:
             if cgroup != dest:
@@ -288,10 +288,8 @@ class CGroup(object):
     def get(self):
         conf = {}
 
-        logging.debug('Reading %s attributes from:',
-                self.controller.kind)
-        logging.debug('  %s',
-                self.directory)
+        self.logger.debug('Reading %s attributes from:', self.controller.kind)
+        self.logger.debug('  %s', self.directory)
         output = self.target._execute_util(  # pylint: disable=protected-access
                     'cgroups_get_attributes {} {}'.format(
                     self.directory, self.controller.kind),
@@ -330,7 +328,7 @@ class CGroup(object):
 
     def get_tasks(self):
         task_ids = self.target.read_value(self.tasks_file).split()
-        logging.debug('Tasks: %s', task_ids)
+        self.logger.debug('Tasks: %s', task_ids)
         return list(map(int, task_ids))
 
     def add_task(self, tid):


### PR DESCRIPTION
The docstring of `Controller.move_all_tasks_to()` says that the function moves all the tasks to the `dest` cgroup.  However, it iterates over `self._cgroups`, which is a dictionary that is lazily populated when you call `Controller.cgroup()`.  For example, this doesn't work:

``` python
cpuset_cg = target.cgroups.controller("cpuset")
cpuset_cg.move_all_tasks_to("top-app")
```

Because you haven't populated `self._cgroups` yet.  You need to manually populate the dictionary with something like:

``` python
for group in cpuset_cg.list_all():                               
    cpuset_cg.cgroup(group)
```

before you can use `move_all_tasks_to()`.  Iterate through `self.list_all()` instead of `self._cgroups` to really move all tasks to to the destination directory.  

`Controller.move_tasks()` has a try-except block to get the cgroups of the source and destination groups.  `Controller.cgroup()` caches the groups in `self._cgroups` and populates it if it hasn't been already.  Simplify `move_tasks()` and let it deal with source and dest cgroups that exist but the controller hasn't loaded yet.