### PR TITLE
ftrace: Ensure /proc/kallsyms contains symbol addresses

### DIFF
--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -20,6 +20,7 @@ import time
 import re
 import subprocess
 import sys
+import contextlib
 from pipes import quote
 
 from devlib.trace import TraceCollector
@@ -225,6 +226,11 @@ class FtraceCollector(TraceCollector):
             tracecmd_functions = ''
 
         tracer_string = '-p {}'.format(self.tracer) if self.tracer else ''
+
+        # Ensure kallsyms contains addresses if possible, so that function the
+        # collected trace contains enough data for pretty printing
+        with contextlib.suppress(TargetStableError):
+            self.target.write_value('/proc/sys/kernel/kptr_restrict', 0)
 
         self.target.write_value(self.trace_clock_file, self.trace_clock, verify=False)
         try:


### PR DESCRIPTION
The content of /proc/kallsyms depends on the value of
/proc/sys/kernel/kptr_restrict:
* If 0, restriction is lifted and kallsyms contains real addresses
* If 1, kallsyms will contain null pointers

Since trace-cmd records the content of kallsyms into the trace.dat and uses that
to pretty-print function names (function tracer/grapher), ensure that its
content is available.

Signed-off-by: Douglas RAILLARD <douglas.raillard@arm.com>