### PR TITLE
Add NUMA nodes

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -162,6 +162,27 @@ class Target(object):
 
     @property
     @memoized
+    def number_of_nodes(self):
+        num_nodes = 0
+        nodere = re.compile(r'^\s*node\d+\s*$')
+        output = self.execute('ls /sys/devices/system/node', as_root=self.is_rooted)
+        for entry in output.split():
+            if nodere.match(entry):
+                num_nodes += 1
+        return num_nodes
+
+    @property
+    @memoized
+    def list_nodes_cpus(self):
+        nodes_cpus = []
+        for node in range(self.number_of_nodes):
+            path = self.path.join('/sys/devices/system/node/node{}/cpulist'.format(node))
+            output = self.read_value(path)
+            nodes_cpus.append(ranges_to_list(output))
+        return nodes_cpus
+
+    @property
+    @memoized
     def config(self):
         try:
             return KernelConfig(self.execute('zcat /proc/config.gz'))


### PR DESCRIPTION
devlib is used by LISA ( https://github.com/ARM-software/lisa ) for Linux kernel scheduler 
testing. This PR will allow introspection of NUMA typologies.
This PR will allow testing of task placement and migration with respect to 
NUMA topology.