### PR TITLE
target: get model form platform

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -137,6 +137,10 @@ class Target(object):
         return {}
 
     @property
+    def model(self):
+        return self.platform.model
+
+    @property
     def abi(self):  # pylint: disable=no-self-use
         return None
 
@@ -982,17 +986,6 @@ class LinuxTarget(Target):
 
     @property
     @memoized
-    # There is currently no better way to do this cross platform.
-    # ARM does not have dmidecode
-    def model(self):
-        if self.file_exists("/proc/device-tree/model"):
-            raw_model = self.execute("cat /proc/device-tree/model")
-            device_model_to_return = '_'.join(raw_model.split()[:2])
-            return device_model_to_return.rstrip(' \t\r\n\0')
-        return None
-
-    @property
-    @memoized
     def system_id(self):
         return self._execute_util('get_linux_system_id').strip()
 
@@ -1162,14 +1155,6 @@ class AndroidTarget(Target):
         """
         output = self.execute('content query --uri content://settings/secure --projection value --where "name=\'android_id\'"').strip()
         return output.split('value=')[-1]
-
-    @property
-    @memoized
-    def model(self):
-        try:
-            return self.getprop(prop='ro.product.device')
-        except KeyError:
-            return None
 
     @property
     @memoized


### PR DESCRIPTION
Move the resolution of the model name from targets into Platform's
_set_model_from_target() (which was already attempting to do that via
dmidecode method).