### PR TITLE
ssh: Use paramiko instead of pxssh

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -53,7 +53,7 @@ from devlib.utils.android import AdbConnection, AndroidProperties, LogcatMonitor
 from devlib.utils.misc import memoized, isiterable, convert_new_lines
 from devlib.utils.misc import commonprefix, merge_lists
 from devlib.utils.misc import ABI_MAP, get_cpu_name, ranges_to_list
-from devlib.utils.misc import batch_contextmanager
+from devlib.utils.misc import batch_contextmanager, tls_property
 from devlib.utils.types import integer, boolean, bitmask, identifier, caseless_string, bytes_regex
 
 
@@ -215,20 +215,17 @@ class Target(object):
         return int(self.execute(cmd.format(self.busybox)))
 
     @property
-    def conn(self):
-        if self._connections:
-            tid = id(threading.current_thread())
-            if tid not in self._connections:
-                self._connections[tid] = self.get_connection()
-            return self._connections[tid]
-        else:
-            return None
-
-    @property
     def shutils(self):
         if self._shutils is None:
             self._setup_shutils()
         return self._shutils
+
+    @tls_property
+    def _conn(self):
+        return self.get_connection()
+
+    # Add a basic property that does not require calling to get the value
+    conn = _conn.basic_property
 
     def __init__(self,
                  connection_settings=None,
@@ -242,6 +239,7 @@ class Target(object):
                  conn_cls=None,
                  is_container=False
                  ):
+
         self._is_rooted = None
         self.connection_settings = connection_settings or {}
         # Set self.platform: either it's given directly (by platform argument)
@@ -271,7 +269,6 @@ class Target(object):
         self._installed_binaries = {}
         self._installed_modules = {}
         self._cache = {}
-        self._connections = {}
         self._shutils = None
         self._file_transfer_cache = None
         self.busybox = None
@@ -290,8 +287,9 @@ class Target(object):
 
     def connect(self, timeout=None, check_boot_completed=True):
         self.platform.init_target_connection(self)
-        tid = id(threading.current_thread())
-        self._connections[tid] = self.get_connection(timeout=timeout)
+        # Forcefully set the thread-local value for the connection, with the
+        # timeout we want
+        self.conn = self.get_connection(timeout=timeout)
         if check_boot_completed:
             self.wait_boot_complete(timeout)
         self._resolve_paths()
@@ -304,9 +302,9 @@ class Target(object):
             self._install_module(get_module('bl'))
 
     def disconnect(self):
-        for conn in self._connections.values():
+        connections = self._conn.get_all_values()
+        for conn in connections:
             conn.close()
-        self._connections = {}
 
     def get_connection(self, timeout=None):
         if self.conn_cls is None:

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -292,6 +292,7 @@ class Target(object):
         self.conn = self.get_connection(timeout=timeout)
         if check_boot_completed:
             self.wait_boot_complete(timeout)
+        self.check_connection()
         self._resolve_paths()
         self.execute('mkdir -p {}'.format(quote(self.working_directory)))
         self.execute('mkdir -p {}'.format(quote(self.executables_directory)))
@@ -300,6 +301,14 @@ class Target(object):
         self._update_modules('connected')
         if self.platform.big_core and self.load_default_modules:
             self._install_module(get_module('bl'))
+
+    def check_connection(self):
+        """
+        Check that the connection works without obvious issues.
+        """
+        out = self.execute('true', as_root=False)
+        if out.strip():
+            raise TargetStableError('The shell seems to not be functional and adds content to stderr: {}'.format(out))
 
     def disconnect(self):
         connections = self._conn.get_all_values()

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -20,7 +20,7 @@ Miscellaneous functions that don't fit anywhere else.
 """
 from __future__ import division
 from contextlib import contextmanager
-from functools import partial, reduce
+from functools import partial, reduce, wraps
 from itertools import groupby
 from operator import itemgetter
 from weakref import WeakKeyDictionary, WeakSet
@@ -854,3 +854,50 @@ class _BoundTLSProperty:
             instance=self.instance,
             owner=self.owner,
         )
+
+
+class InitCheckpointMeta(type):
+    """
+    Metaclass providing an ``initialized`` boolean attributes on instances.
+
+    ``initialized`` is set to ``True`` once the ``__init__`` constructor has
+    returned. It will deal cleanly with nested calls to ``super().__init__``.
+    """
+    def __new__(metacls, name, bases, dct, **kwargs):
+        cls = super().__new__(metacls, name, bases, dct, **kwargs)
+        init_f = cls.__init__
+
+        @wraps(init_f)
+        def init_wrapper(self, *args, **kwargs):
+            self.initialized = False
+
+            # Track the nesting of super()__init__ to set initialized=True only
+            # when the outer level is finished
+            try:
+                stack = self._init_stack
+            except AttributeError:
+                stack = []
+                self._init_stack = stack
+
+            stack.append(init_f)
+            try:
+                x = init_f(self, *args, **kwargs)
+            finally:
+                stack.pop()
+
+            if not stack:
+                self.initialized = True
+                del self._init_stack
+
+            return x
+
+        cls.__init__ = init_wrapper
+
+        return cls
+
+
+class InitCheckpoint(metaclass=InitCheckpointMeta):
+    """
+    Inherit from this class to set the :class:`InitCheckpointMeta` metaclass.
+    """
+    pass

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ params = dict(
         'python-dateutil',  # converting between UTC and local time.
         'pexpect>=3.3',  # Send/recieve to/from device
         'pyserial',  # Serial port interface
+        'paramiko', # SSH connection
         'wrapt',  # Basic for construction of decorator functions
         'future', # Python 2-3 compatibility
         'enum34;python_version<"3.4"', # Enums for Python < 3.4


### PR DESCRIPTION
Here is an crude port of SshConnection to paramiko, so pxssh can rest in peace.

Quote from a pexpect maintainer in 2014 on https://github.com/DFE/MONK/issues/108:
> As a maintainer of pexpect, I highly recommend using paramiko instead of pexpect for ssh :) pexpect's ssh support is from long ago where no native-ssh option existed, it only remains for compatibility.
With paramiko, remote programs will not detect you as a terminal and will not likely write terminal sequences.

Note: it might be a better idea to just introduce a new class rather than ruthlessly modifying SshConnection, since TelnetConnection relies on pexpect and the recent addition of `options` parameter will not allow easily moving away from an actual ssh/scp command. (paramiko seems to have an OpenSSH config emulation, maybe that would allow that to work ...)

Note2: Some APIs that were not properly abstracted are also somewhat broken, like `background()` method that leaked a `Popen` object, rather than just giving a handle on stdin/stdout/stderr like paramiko does.

All in all, it took 2h to go from scratch to something that seem to work well enough for LISA, which is less than 10% of the time spent chasing TTY size issues (worked around but not really fixed AFAIR) and control sequences issues (https://github.com/ARM-software/devlib/issues/442). It also reduces by 2 the mount of code in `SshConnection`, mostly removing cruft related to interactive terminal management:
```
 2 files changed, 79 insertions(+), 159 deletions(-)
```
