### PR TITLE
[Breaking Change] ADB Refactor

### DIFF
--- a/devlib/host.py
+++ b/devlib/host.py
@@ -109,6 +109,12 @@ class LocalConnection(object):
     def cancel_running_command(self):
         pass
 
+    def wait_for_device(self, timeout=30):
+        return
+
+    def reboot_bootloader(self, timeout=30):
+        raise NotImplementedError()
+
     def _get_password(self):
         if self.password:
             return self.password

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1225,13 +1225,6 @@ class AndroidTarget(Target):
 
     def connect(self, timeout=30, check_boot_completed=True):  # pylint: disable=arguments-differ
         device = self.connection_settings.get('device')
-        if device and ':' in device:
-            # ADB does not automatically remove a network device from it's
-            # devices list when the connection is broken by the remote, so the
-            # adb connection may have gone "stale", resulting in adb blocking
-            # indefinitely when making calls to the device. To avoid this,
-            # always disconnect first.
-            adb_disconnect(device)
         super(AndroidTarget, self).connect(timeout=timeout, check_boot_completed=check_boot_completed)
 
     def kick_off(self, command, as_root=None):

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1530,27 +1530,11 @@ class AndroidTarget(Target):
     def get_logcat_monitor(self, regexps=None):
         return LogcatMonitor(self, regexps)
 
-    def adb_kill_server(self, timeout=30):
-        if not isinstance(self.conn, AdbConnection):
-            raise TargetStableError('Cannot issues adb command without adb connection')
-        adb_command(self.adb_name, 'kill-server', timeout)
+    def wait_for_device(self, timeout=30):
+        self.conn.wait_for_device()
 
-    def adb_wait_for_device(self, timeout=30):
-        if not isinstance(self.conn, AdbConnection):
-            raise TargetStableError('Cannot issues adb command without adb connection')
-        adb_command(self.adb_name, 'wait-for-device', timeout)
-
-    def adb_reboot_bootloader(self, timeout=30):
-        if not isinstance(self.conn, AdbConnection):
-            raise TargetStableError('Cannot issues adb command without adb connection')
-        adb_command(self.adb_name, 'reboot-bootloader', timeout)
-
-    def adb_root(self, enable=True, force=False):
-        if not isinstance(self.conn, AdbConnection):
-            raise TargetStableError('Cannot enable adb root without adb connection')
-        if enable and self.connected_as_root and not force:
-            return
-        self.conn.adb_root(enable=enable)
+    def reboot_bootloader(self, timeout=30):
+        self.conn.reboot_bootloader()
 
     def is_screen_on(self):
         output = self.execute('dumpsys power')

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -424,6 +424,12 @@ def adb_connect(device, timeout=None, attempts=MAX_ATTEMPTS):
         tries += 1
         if device:
             if "." in device: # Connect is required only for ADB-over-IP
+                # ADB does not automatically remove a network device from it's
+                # devices list when the connection is broken by the remote, so the
+                # adb connection may have gone "stale", resulting in adb blocking
+                # indefinitely when making calls to the device. To avoid this,
+                # always disconnect first.
+                adb_disconnect(device)
                 command = 'adb connect {}'.format(quote(device))
                 logger.debug(command)
                 output, _ = check_output(command, shell=True, timeout=timeout)

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -317,7 +317,7 @@ class AdbConnection(object):
         AdbConnection.active_connections[self.device] -= 1
         if AdbConnection.active_connections[self.device] <= 0:
             if self.adb_as_root:
-                adb_root(self.device, enable=False)
+                self.adb_root(self.device, enable=False)
             adb_disconnect(self.device)
             del AdbConnection.active_connections[self.device]
 
@@ -333,6 +333,12 @@ class AdbConnection(object):
         if 'cannot run as root in production builds' in output:
             raise TargetStableError(output)
         AdbConnection._connected_as_root[self.device] = enable
+
+    def wait_for_device(self, timeout=30):
+        adb_command(self.device, 'wait-for-device', timeout)
+
+    def reboot_bootloader(self, timeout=30):
+        adb_command(self.device, 'reboot-bootloader', timeout)
 
     # Again, we need to handle boards where the default output format from ls is
     # single column *and* boards where the default output is multi-column.
@@ -543,6 +549,8 @@ def adb_background_shell(device, command,
     logger.debug(full_command)
     return subprocess.Popen(full_command, stdout=stdout, stderr=stderr, shell=True)
 
+def adb_kill_server(self, timeout=30):
+    adb_command(None, 'kill-server', timeout)
 
 def adb_list_devices(adb_server=None):
     output = adb_command(None, 'devices', adb_server=adb_server)

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -299,6 +299,12 @@ class SshConnection(object):
                 return True
         return False
 
+    def wait_for_device(self, timeout=30):
+        return
+
+    def reboot_bootloader(self, timeout=30):
+        raise NotImplementedError()
+
     def _execute_and_wait_for_prompt(self, command, timeout=None, as_root=False, strip_colors=True, log=True):
         self.conn.prompt(0.1)  # clear an existing prompt if there is one.
         if as_root and self.connected_as_root:
@@ -633,6 +639,19 @@ class Gem5Connection(TelnetConnection):
 
         # Delete the lock file
         os.remove(self.lock_file_name)
+
+    def wait_for_device(self, timeout=30):
+        """
+        Wait for Gem5 to be ready for interation with a timeout.
+        """
+        for _ in attempts(timeout):
+            if self.ready:
+                return
+            time.sleep(1)
+        raise TimeoutError('Gem5 is not ready for interaction')
+
+    def reboot_bootloader(self, timeout=30):
+        raise NotImplementedError()
 
     # Functions only to be called by the Gem5 connection itself
     def _connect_gem5_platform(self, platform):

--- a/doc/target.rst
+++ b/doc/target.rst
@@ -647,6 +647,14 @@ Android Target
    Returns ``True`` if the targets screen is currently on and ``False``
    otherwise.
 
+.. method:: AndroidTarget.wait_for_target(timeout=30)
+
+    Returns when the devices becomes available withing the given timeout
+    otherwise returns a ``TimeoutError``.
+
+.. method:: AndroidTarget.reboot_bootloader(timeout=30)
+    Attempts to reboot the target into it's bootloader.
+
 .. method:: AndroidTarget.homescreen()
 
    Returns the device to its home screen.


### PR DESCRIPTION
As per https://github.com/ARM-software/devlib/issues/410, `AndroidTarget` should be independent to the underlying connection, therefore move ADB specific methods into the `AdbConnection`.