### PR TITLE
devlib/AndroidTarget: Allow passing format options to dump_logcat()

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1507,15 +1507,18 @@ class AndroidTarget(Target):
         self._ensure_executables_directory_is_writable()
         self.remove(on_device_executable, as_root=self.needs_su)
 
-    def dump_logcat(self, filepath, filter=None, append=False, timeout=30):  # pylint: disable=redefined-builtin
+    def dump_logcat(self, filepath, filter=None, logcat_format=None, append=False,
+                    timeout=30):  # pylint: disable=redefined-builtin
         op = '>>' if append else '>'
         filtstr = ' -s {}'.format(quote(filter)) if filter else ''
+        formatstr = ' -v {}'.format(quote(logcat_format)) if logcat_format else ''
+        logcat_opts = '-d' + formatstr + filtstr
         if isinstance(self.conn, AdbConnection):
-            command = 'logcat -d{} {} {}'.format(filtstr, op, quote(filepath))
+            command = 'logcat {} {} {}'.format(logcat_opts, op, quote(filepath))
             adb_command(self.adb_name, command, timeout=timeout)
         else:
             dev_path = self.get_workpath('logcat')
-            command = 'logcat -d{} {} {}'.format(filtstr, op, quote(dev_path))
+            command = 'logcat {} {} {}'.format(logcat_opts, op, quote(dev_path))
             self.execute(command, timeout=timeout)
             self.pull(dev_path, filepath)
             self.remove(dev_path)


### PR DESCRIPTION
logcat has a modifier for its output format.  Add a `logcat_format` parameter to `dump_logcat()` so that we can pass it on to logcat.