### PR TITLE
Combined output fix

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -509,7 +509,7 @@ def adb_shell(device, command, timeout=None, check_exit_code=False,
 
     logger.debug(' '.join(quote(part) for part in parts))
     try:
-        raw_output, _ = check_output(parts, timeout, shell=False, combined_output=True)
+        raw_output, error = check_output(parts, timeout, shell=False)
     except subprocess.CalledProcessError as e:
         raise TargetStableError(str(e))
 
@@ -529,8 +529,8 @@ def adb_shell(device, command, timeout=None, check_exit_code=False,
         if exit_code.isdigit():
             if int(exit_code):
                 message = ('Got exit code {}\nfrom target command: {}\n'
-                           'OUTPUT: {}')
-                raise TargetStableError(message.format(exit_code, command, output))
+                           'OUTPUT: {}\nSTDERR: {}\n')
+                raise TargetStableError(message.format(exit_code, command, output, error))
             elif re_search:
                 message = 'Could not start activity; got the following:\n{}'
                 raise TargetStableError(message.format(re_search[0]))
@@ -541,10 +541,10 @@ def adb_shell(device, command, timeout=None, check_exit_code=False,
             else:
                 message = 'adb has returned early; did not get an exit code. '\
                           'Was kill-server invoked?\nOUTPUT:\n-----\n{}\n'\
-                          '-----'
-                raise TargetTransientError(message.format(raw_output))
+                          '-----\nSTDERR:\n-----\n{}\n-----'
+                raise TargetTransientError(message.format(raw_output, error))
 
-    return output
+    return output + error
 
 
 def adb_background_shell(conn, command,

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -155,8 +155,7 @@ check_output_logger = logging.getLogger('check_output')
 check_output_lock = threading.Lock()
 
 
-def check_output(command, timeout=None, ignore=None, inputtext=None,
-                 combined_output=False, **kwargs):
+def check_output(command, timeout=None, ignore=None, inputtext=None, **kwargs):
     """This is a version of subprocess.check_output that adds a timeout parameter to kill
     the subprocess if it does not return within the specified time."""
     # pylint: disable=too-many-branches
@@ -171,10 +170,9 @@ def check_output(command, timeout=None, ignore=None, inputtext=None,
         raise ValueError('stdout argument not allowed, it will be overridden.')
 
     with check_output_lock:
-        stderr = subprocess.STDOUT if combined_output else subprocess.PIPE
         process = subprocess.Popen(command,
                                    stdout=subprocess.PIPE,
-                                   stderr=stderr,
+                                   stderr=subprocess.PIPE,
                                    stdin=subprocess.PIPE,
                                    preexec_fn=preexec_function,
                                    **kwargs)
@@ -188,8 +186,7 @@ def check_output(command, timeout=None, ignore=None, inputtext=None,
 
     # Currently errors=replace is needed as 0x8c throws an error
     output = output.decode(sys.stdout.encoding or 'utf-8', "replace")
-    if error:
-        error = error.decode(sys.stderr.encoding or 'utf-8', "replace")
+    error = error.decode(sys.stderr.encoding or 'utf-8', "replace")
 
     if timeout_expired:
         raise TimeoutError(command, output='\n'.join([output or '', error or '']))


### PR DESCRIPTION
`check_output(combined_output=True)` does not guarantee that stdout will come before stderr, but the ordering is needed in case `check_exit_code` is `True`, as we are expecting the exit code at the end of stdout. Furthermore, the exceptions can't report what is stdout and what is stderr as they are combined.

Partially revert 77a6de9 ("utils/android: include stderr in adb_shell output") and parse output and err independently. Return them combined from `adb_shell()` to keep the functionality that 77a6de9 was
implementing.