### PR TITLE
utils/check_output: Only attempt to decode output if present.

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -185,15 +185,15 @@ def check_output(command, timeout=None, ignore=None, inputtext=None, **kwargs):
         timeout_expired = None
 
     # Currently errors=replace is needed as 0x8c throws an error
-    output = output.decode(sys.stdout.encoding or 'utf-8', "replace")
-    error = error.decode(sys.stderr.encoding or 'utf-8', "replace")
+    output = output.decode(sys.stdout.encoding or 'utf-8', "replace") if output else ''
+    error = error.decode(sys.stderr.encoding or 'utf-8', "replace") if output else ''
 
     if timeout_expired:
-        raise TimeoutError(command, output='\n'.join([output or '', error or '']))
+        raise TimeoutError(command, output='\n'.join([output, error]))
 
     retcode = process.poll()
     if retcode and ignore != 'all' and retcode not in ignore:
-        raise subprocess.CalledProcessError(retcode, command, output='\n'.join([output or '', error or '']))
+        raise subprocess.CalledProcessError(retcode, command, output='\n'.join([output, error]))
     return output, error
 
 


### PR DESCRIPTION
If an error occurs while executing a command the `output` and `error`
variables may not get initialised, only attempted to decode their
contents if this is not the case.