### PR TITLE
utils/check_output: Ensure `output` and `error` are always initialised.

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -177,6 +177,8 @@ def check_output(command, timeout=None, ignore=None, inputtext=None, **kwargs):
                                    preexec_fn=preexec_function,
                                    **kwargs)
 
+    output = None
+    error = None
     try:
         output, error = process.communicate(inputtext, timeout=timeout)
     except subprocess.TimeoutExpired as e:


### PR DESCRIPTION
Ensure that the `output` and `error` variables are always initialised
regardless of whether an error occurs during execution.