### PR TITLE
collector/perf: Disable pager for perf event list.

### DIFF
--- a/devlib/collector/perf.py
+++ b/devlib/collector/perf.py
@@ -236,7 +236,7 @@ class PerfCollector(CollectorBase):
         self.target.execute(report_command)
 
     def _validate_events(self, events):
-        available_events_string = self.target.execute('{} list'.format(self.perf_type))
+        available_events_string = self.target.execute('{} list | {} cat'.format(self.perf_type, self.target.busybox))
         available_events = available_events_string.splitlines()
         for available_event in available_events:
             if available_event == '':


### PR DESCRIPTION
Pipe the list of perf events via cat to ensure that a pager is not
used to display the output as this can cause some systems to hang
waiting for user input.