### PR TITLE
utils/android: Expose `connection_attempts` argument to `AdbConnection`

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -264,7 +264,7 @@ class AdbConnection(ConnectionBase):
 
     # pylint: disable=unused-argument
     def __init__(self, device=None, timeout=None, platform=None, adb_server=None,
-                 adb_as_root=False):
+                 adb_as_root=False, connection_attempts=MAX_ATTEMPTS):
         super().__init__()
         self.timeout = timeout if timeout is not None else self.default_timeout
         if device is None:
@@ -274,7 +274,7 @@ class AdbConnection(ConnectionBase):
         self.adb_as_root = adb_as_root
         if self.adb_as_root:
             self.adb_root(enable=True)
-        adb_connect(self.device, adb_server=self.adb_server)
+        adb_connect(self.device, adb_server=self.adb_server, attempts=connection_attempts)
         AdbConnection.active_connections[self.device] += 1
         self._setup_ls()
         self._setup_su()

--- a/doc/connection.rst
+++ b/doc/connection.rst
@@ -104,7 +104,7 @@ Connection Types
 
 .. module:: devlib.utils.android
 
-.. class:: AdbConnection(device=None, timeout=None, adb_server=None, adb_as_root=False)
+.. class:: AdbConnection(device=None, timeout=None, adb_server=None, adb_as_root=False, connection_attempts=MAX_ATTEMPTS)
 
     A connection to an android device via ``adb`` (Android Debug Bridge).
     ``adb`` is part of the Android SDK (though stand-alone versions are also
@@ -119,6 +119,9 @@ Connection Types
                     is raised.
     :param adb_server: Allows specifying the address of the adb server to use.
     :param adb_as_root: Specify whether the adb server should be restarted in root mode.
+    :param connection_attempts: Specify how many connection attempts, 10 seconds
+                                apart, should be attempted to connect to the device.
+                                Defaults to 5.
 
 .. module:: devlib.utils.ssh
 


### PR DESCRIPTION
Allow for configuring the number of connection attempts that will be
made to the device before failing to connect. This allows for waiting longer
periods of time for the device to come online.