### PR TITLE
LogcatCollector: Learn to pass format to logcat

### DIFF
--- a/devlib/collector/logcat.py
+++ b/devlib/collector/logcat.py
@@ -22,9 +22,10 @@ from devlib.utils.android import LogcatMonitor
 
 class LogcatCollector(CollectorBase):
 
-    def __init__(self, target, regexps=None):
+    def __init__(self, target, regexps=None, logcat_format=None):
         super(LogcatCollector, self).__init__(target)
         self.regexps = regexps
+        self.logcat_format = logcat_format
         self.output_path = None
         self._collecting = False
         self._prev_log = None
@@ -49,7 +50,7 @@ class LogcatCollector(CollectorBase):
         """
         if self.output_path is None:
             raise RuntimeError("Output path was not set.")
-        self._monitor = LogcatMonitor(self.target, self.regexps)
+        self._monitor = LogcatMonitor(self.target, self.regexps, logcat_format=self.logcat_format)
         if self._prev_log:
             # Append new data collection to previous collection
             self._monitor.start(self._prev_log)

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -714,11 +714,12 @@ class LogcatMonitor(object):
     def logfile(self):
         return self._logfile
 
-    def __init__(self, target, regexps=None):
+    def __init__(self, target, regexps=None, logcat_format=None):
         super(LogcatMonitor, self).__init__()
 
         self.target = target
         self._regexps = regexps
+        self._logcat_format = logcat_format
         self._logcat = None
         self._logfile = None
 
@@ -749,6 +750,9 @@ class LogcatMonitor(object):
                 logcat_cmd = '{} -e {}'.format(logcat_cmd, quote(regexp))
             else:
                 logcat_cmd = '{} | grep {}'.format(logcat_cmd, quote(regexp))
+
+        if self._logcat_format:
+            logcat_cmd = "{} -v {}".format(logcat_cmd, quote(self._logcat_format))
 
         logcat_cmd = get_adb_command(self.target.conn.device, logcat_cmd)
 


### PR DESCRIPTION
logcat -v lets you specify the format for the logcat output.  Add a
parameter to the LogcatCollector to allow us to pass that information
down to the logcat invocation.