### PR TITLE
utils/ssh: Do not attempt to push files recursivley and add logging

### DIFF
--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -444,7 +444,8 @@ class SshConnection(SshConnectionBase):
         try:
             sftp.put(src, dst)
         # Maybe the dst was a folder
-        except OSError:
+        except OSError as e:
+            logger.debug('sftp transfer error: {}'.format(repr(e)))
             # This might fail if the folder already exists
             with contextlib.suppress(IOError):
                 sftp.mkdir(dst)
@@ -453,8 +454,8 @@ class SshConnection(SshConnectionBase):
                 dst,
                 os.path.basename(src),
             )
-
-            return cls._push_file(sftp, src, new_dst)
+            logger.debug('Trying: {} -> {}'.format(src, new_dst))
+            sftp.put(src, new_dst)
 
 
     @classmethod


### PR DESCRIPTION
No longer recursively attempt to push a file to the target. If the
second attempt goes wrong we assume there is something else wrong and
therefore let the error propagate.
Also log the original error in case it is not the error we were
expecting.