### PR TITLE
utils/android: Allow instantiating an ApkInfo object without a path.

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -152,7 +152,11 @@ class ApkInfo(object):
         self.version_code = None
         self.native_code = None
         self.permissions = []
-        self.parse(path)
+        self._apk_path = None
+        self._activities = None
+        self._methods = None
+        if path:
+            self.parse(path)
 
     # pylint: disable=too-many-branches
     def parse(self, apk_path):


### PR DESCRIPTION
Do not assume that a path is provided upon creating of an ApkInfo
instance and only attempt to extract information if present.