### PR TITLE
[RFC] Update android tools discovery

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -168,7 +168,7 @@ Process Control
    # PsEntry records.
    entries = t.ps()
    # e.g.  print virtual memory sizes of all running sshd processes:
-   print ', '.join(str(e.vsize) for e in entries if e.name == 'sshd')
+   print(', '.join(str(e.vsize) for e in entries if e.name == 'sshd'))
 
 
 More...


### PR DESCRIPTION
Allows falling back to discovering of the currently required android tools from PATH instead of an Android SDK installation. 

Enable the discovery of `aapt2` and default to this if a suitable binary is found:
- This is required due to the fact that `appt` is now depreciated and cannot handle some apks which have valid characters in their description.
- Unfortunately `aapt2` versioning does not seem very mature yet and does not have a nice way of determining whether a particular version supports the subcommands that devlib requires. For example the `version` output from a known working version is `Android Asset Packaging Tool (aapt) 2.19-SOONG BUILD NUMBER PLACEHOLDER`. 
- Therefore to detect if a suitable version is present, try to execute a sub command and look for an expected error message as opposed to a unknown command error. 

Supersedes: https://github.com/ARM-software/devlib/pull/467