### PR TITLE
target/reset: Ignore all `TargetError`s when rebooting

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -550,7 +550,7 @@ class Target(object):
     def reset(self):
         try:
             self.execute('reboot', as_root=self.needs_su, timeout=2)
-        except (DevlibTransientError, subprocess.CalledProcessError):
+        except (TargetError, subprocess.CalledProcessError):
             # on some targets "reboot" doesn't return gracefully
             pass
         self.conn.connected_as_root = None


### PR DESCRIPTION
Some targets can thrown stable errors in addition to
transient errors when executing the `reboot` command.
We expect this command to not always complete cleanly
so ignore all target errors.