### PR TITLE
target: support threads in ps

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1163,16 +1163,20 @@ class LinuxTarget(Target):
         else:
             return []
 
-    def ps(self, **kwargs):
-        command = 'ps -eo user,pid,ppid,vsize,rss,wchan,pcpu,state,fname'
+    def ps(self, threads=False, **kwargs):
+        ps_flags = '-eo'
+        if threads:
+            ps_flags = '-eLo'
+        command = 'ps {} user,pid,tid,ppid,vsize,rss,wchan,pcpu,state,fname'.format(ps_flags)
+
         lines = iter(convert_new_lines(self.execute(command)).split('\n'))
         next(lines)  # header
 
         result = []
         for line in lines:
-            parts = re.split(r'\s+', line, maxsplit=8)
+            parts = re.split(r'\s+', line, maxsplit=9)
             if parts and parts != ['']:
-                result.append(PsEntry(*(parts[0:1] + list(map(int, parts[1:5])) + parts[5:])))
+                result.append(PsEntry(*(parts[0:1] + list(map(int, parts[1:6])) + parts[6:])))
 
         if not kwargs:
             return result
@@ -1419,18 +1423,32 @@ class AndroidTarget(Target):
                 result.append(entry.pid)
         return result
 
-    def ps(self, **kwargs):
-        lines = iter(convert_new_lines(self.execute('ps')).split('\n'))
+    def ps(self, threads=False, **kwargs):
+        maxsplit = 9 if threads else 8
+        command = 'ps'
+        if threads:
+            command = 'ps -AT'
+
+        lines = iter(convert_new_lines(self.execute(command)).split('\n'))
         next(lines)  # header
         result = []
         for line in lines:
-            parts = line.split(None, 8)
+            parts = line.split(None, maxsplit)
             if not parts:
                 continue
-            if len(parts) == 8:
+
+            wchan_missing = False
+            if len(parts) == maxsplit:
+                wchan_missing = True
+
+            if not threads:
+                # Duplicate PID into TID location.
+                parts.insert(2, parts[1])
+
+            if wchan_missing:
                 # wchan was blank; insert an empty field where it should be.
-                parts.insert(5, '')
-            result.append(PsEntry(*(parts[0:1] + list(map(int, parts[1:5])) + parts[5:])))
+                parts.insert(6, '')
+            result.append(PsEntry(*(parts[0:1] + list(map(int, parts[1:6])) + parts[6:])))
         if not kwargs:
             return result
         else:
@@ -1854,7 +1872,7 @@ class AndroidTarget(Target):
         self.write_value(self._charging_enabled_path, int(bool(enabled)))
 
 FstabEntry = namedtuple('FstabEntry', ['device', 'mount_point', 'fs_type', 'options', 'dump_freq', 'pass_num'])
-PsEntry = namedtuple('PsEntry', 'user pid ppid vsize rss wchan pc state name')
+PsEntry = namedtuple('PsEntry', 'user pid tid ppid vsize rss wchan pc state name')
 LsmodEntry = namedtuple('LsmodEntry', ['name', 'size', 'use_count', 'used_by'])
 
 


### PR DESCRIPTION
By passing 'threads=True' to target.ps(), a list of PsThreadEntrys will be
returned for all threads in the target, not just processes. These entries
include an extra value 'tid': the thread ID of this thread. The 'pid' value
represents the pid of the process the thread belongs to.