### PR TITLE
utils/ssh: Remove sudo prompt from output

### DIFF
--- a/devlib/host.py
+++ b/devlib/host.py
@@ -101,7 +101,7 @@ class LocalConnection(ConnectionBase):
             if self.unrooted:
                 raise TargetStableError('unrooted')
             password = self._get_password()
-            command = 'echo {} | sudo -S -- sh -c '.format(quote(password)) + quote(command)
+            command = 'echo {} | sudo -p ' ' -S -- sh -c '.format(quote(password)) + quote(command)
         ignore = None if check_exit_code else 'all'
         try:
             return check_output(command, shell=True, timeout=timeout, ignore=ignore)[0]
@@ -118,7 +118,7 @@ class LocalConnection(ConnectionBase):
             if self.unrooted:
                 raise TargetStableError('unrooted')
             password = self._get_password()
-            command = 'echo {} | sudo -S '.format(quote(password)) + command
+            command = 'echo {} | sudo -p ' ' -S '.format(quote(password)) + command
 
         # Make sure to get a new PGID so PopenBackgroundCommand() can kill
         # all sub processes that could be started without troubles.

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -284,7 +284,7 @@ class SshConnectionBase(ConnectionBase):
                  keyfile=None,
                  port=None,
                  platform=None,
-                 sudo_cmd="sudo -S -- sh -c {}",
+                 sudo_cmd="sudo -p ' ' -S -- sh -c {}",
                  strict_host_check=True,
                  ):
         super().__init__()
@@ -364,7 +364,7 @@ class SshConnection(SshConnectionBase):
                  port=22,
                  timeout=None,
                  platform=None,
-                 sudo_cmd="sudo -S -- sh -c {}",
+                 sudo_cmd="sudo -p ' ' -S -- sh -c {}",
                  strict_host_check=True,
                  use_scp=False
                  ):


### PR DESCRIPTION
On a target where sudo is required, target.file_exists() erroneously
returns True despite the execute() output being:

  '[sudo] password for valsch01: 0\n'

The sudo prompt is being written to stderr (as per sudo -S), but this is
still merged into the final execute() output. Get rid of the prompt to
prevent it from interfering with any command output processor.