### PR TITLE
devlib.utils: Fix escape sequences

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -623,7 +623,7 @@ def grant_app_permissions(target, package):
     dumpsys = target.execute('dumpsys package {}'.format(package))
 
     permissions = re.search(
-        'requested permissions:\s*(?P<permissions>(android.permission.+\s*)+)', dumpsys
+        r'requested permissions:\s*(?P<permissions>(android.permission.+\s*)+)', dumpsys
     )
     if permissions is None:
         return

--- a/devlib/utils/gem5.py
+++ b/devlib/utils/gem5.py
@@ -18,7 +18,7 @@ import logging
 from devlib.utils.types import numeric
 
 
-GEM5STATS_FIELD_REGEX = re.compile("^(?P<key>[^- ]\S*) +(?P<value>[^#]+).+$")
+GEM5STATS_FIELD_REGEX = re.compile(r"^(?P<key>[^- ]\S*) +(?P<value>[^#]+).+$")
 GEM5STATS_DUMP_HEAD = '---------- Begin Simulation Statistics ----------'
 GEM5STATS_DUMP_TAIL = '---------- End Simulation Statistics   ----------'
 GEM5STATS_ROI_NUMBER = 8

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -486,7 +486,7 @@ def escape_spaces(text):
 
     .. note:: :func:`pipes.quote` should be favored where possible.
     """
-    return text.replace(' ', '\ ')
+    return text.replace(' ', '\\ ')
 
 
 def getch(count=1):

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -1354,7 +1354,7 @@ class Gem5Connection(TelnetConnection):
         both of these.
         """
         gem5_logger.debug("Sending Sync")
-        self.conn.send("echo \*\*sync\*\*\n")
+        self.conn.send("echo \\*\\*sync\\*\\*\n")
         self.conn.expect(r"\*\*sync\*\*", timeout=self.default_timeout)
         self.conn.expect([self.conn.UNIQUE_PROMPT, self.conn.PROMPT], timeout=self.default_timeout)
         self.conn.expect([self.conn.UNIQUE_PROMPT, self.conn.PROMPT], timeout=self.default_timeout)


### PR DESCRIPTION
Fix invalid escape sequence, mostly in regex that were not r-strings.