### PR TITLE
[RFC] Fix broken XML parsing due to android tools update

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -20,18 +20,19 @@ Utility functions for working with Android devices through adb.
 """
 # pylint: disable=E1103
 import glob
-import os
-import re
-import sys
-import time
 import logging
-import tempfile
-import subprocess
-from collections import defaultdict
+import os
 import pexpect
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
 import xml.etree.ElementTree
 import zipfile
-import uuid
+
+from collections import defaultdict
 
 try:
     from shlex import quote

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -29,10 +29,11 @@ import sys
 import tempfile
 import time
 import uuid
-import xml.etree.ElementTree
 import zipfile
 
 from collections import defaultdict
+from io import StringIO
+from lxml import etree
 
 try:
     from shlex import quote
@@ -228,7 +229,10 @@ class ApkInfo(object):
                 command = [dexdump, '-l', 'xml', extracted]
                 dump = self._run(command)
 
-            xml_tree = xml.etree.ElementTree.fromstring(dump)
+            # Dexdump from build tools v30.0.X does not seem to produce
+            # valid xml from certain APKs so ignore errors and attempt to recover.
+            parser = etree.XMLParser(encoding='utf-8', recover=True)
+            xml_tree = etree.parse(StringIO(dump), parser)
 
             package = next((i for i in xml_tree.iter('package')
                            if i.attrib['name'] == self.package), None)

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -734,11 +734,13 @@ def _discover_aapt(env):
         aapt2_path = ''
         versions = os.listdir(env.build_tools)
         for version in reversed(sorted(versions)):
-            if not aapt2_path and not os.path.isfile(aapt2_path):
+            if not os.path.isfile(aapt2_path):
                 aapt2_path = os.path.join(env.build_tools, version, 'aapt2')
-            if not aapt_path and not os.path.isfile(aapt_path):
+            if not os.path.isfile(aapt_path):
                 aapt_path = os.path.join(env.build_tools, version, 'aapt')
                 aapt_version = 1
+            # Use latest available version for aapt/appt2 but ensure at least one is valid.
+            if os.path.isfile(aapt2_path) or os.path.isfile(aapt_path):
                 break
 
         # Use aapt2 only if present and we have a suitable version

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ params = dict(
         'numpy; python_version>="3"',
         'pandas<=0.24.2; python_version<"3"',
         'pandas; python_version>"3"',
+        'lxml', # More robust xml parsing
     ],
     extras_require={
         'daq': ['daqpower>=2'],


### PR DESCRIPTION
As detailed in https://github.com/ARM-software/workload-automation/issues/1151 dexdump in the latest releases (v30.0.1, v30.0.2 and v30.0.3) of android build tools can produce invalid xml due to not escaping special values contained within some APK files.

The built in `xml` module does not seem capable of handling invalid xml data therefore the proposed solution is to switch to the `lxml` module instead which is better equipped to recover data from invalid input.

-----
Additionally fix an issue with `aapt` discovery when presented with an unexpected directory structure.