### PR TITLE
target: increase dump_logcat timeout

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1667,7 +1667,7 @@ class AndroidTarget(Target):
         self.remove(on_device_executable, as_root=self.needs_su)
 
     def dump_logcat(self, filepath, filter=None, logcat_format=None, append=False,
-                    timeout=30):  # pylint: disable=redefined-builtin
+                    timeout=60):  # pylint: disable=redefined-builtin
         op = '>>' if append else '>'
         filtstr = ' -s {}'.format(quote(filter)) if filter else ''
         formatstr = ' -v {}'.format(quote(logcat_format)) if logcat_format else ''


### PR DESCRIPTION
If WA is connected to a phone via a slow connection, dump_logcat() may
timeout when dumping logcat after the job has finished:

    2021-01-11 09:38:16,277 DEBUG       android:         adb -s X.Y.Z.X:5555 logcat -d -v threadtime > wa_output/wk1-wkld-1/logcat.log
    2021-01-11 09:38:46,317 DEBUG        signal:         Sending error-logged from <ErrorSignalHandler (DEBUG)>
    2021-01-11 09:38:46,318 DEBUG        signal:         Disconnecting <bound method Executor._error_signalled_callback of executor> from error-logged(<class 'louie.sender.Any'>)
    2021-01-11 09:38:46,317 ERROR        signal:         Timed out: adb -s X.Y.Z.X:5555 logcat -d -v threadtime > wa_output/wk1-wkld-1/logcat.log
    2021-01-11 09:38:46,317 ERROR        signal:         OUTPUT:
    2021-01-11 09:38:46,317 ERROR        signal:
    2021-01-11 09:38:46,317 ERROR        signal:

Increase the timeout to prevent this.