### PR TITLE
utils/version: Prevent installation failure on systems without git

### DIFF
--- a/devlib/utils/version.py
+++ b/devlib/utils/version.py
@@ -33,8 +33,11 @@ def get_devlib_version():
 
 
 def get_commit():
-    p = Popen(['git', 'rev-parse', 'HEAD'], cwd=os.path.dirname(__file__),
-              stdout=PIPE, stderr=PIPE)
+    try:
+        p = Popen(['git', 'rev-parse', 'HEAD'], cwd=os.path.dirname(__file__),
+                  stdout=PIPE, stderr=PIPE)
+    except FileNotFoundError:
+        return None
     std, _ = p.communicate()
     p.wait()
     if p.returncode:


### PR DESCRIPTION
On systems that do not have git installed devlib will currently fail
to install with a FileNotFound Exception. If git is not present then
we will not have a commit hash so just ignore this error.