### PR TITLE
collector/perf: Run perf as root if the target is rooted

### DIFF
--- a/devlib/collector/perf.py
+++ b/devlib/collector/perf.py
@@ -141,7 +141,7 @@ class PerfCollector(CollectorBase):
 
     def start(self):
         for command in self.commands:
-            self.target.kick_off(command)
+            self.target.kick_off(command, as_root=self.target.is_rooted)
 
     def stop(self):
         self.target.killall(self.perf_type, signal='SIGINT',


### PR DESCRIPTION
If you want to collect events by event id (eg. in simpleperf, "rNNN" with NNN a number), you must run it as root.  Otherwise, simpleperf fails with a SIGABRT:

    simpleperf F environment.cpp:856] Check failed: tmp_file->fd != -1 (tmp_file->fd=-1, -1=-1)
    Aborted

Run simpleperf as root by default if the target is rooted to avoid this.