### PR TITLE
host and ssh: Fix sudo invocation

### DIFF
--- a/devlib/host.py
+++ b/devlib/host.py
@@ -102,7 +102,7 @@ class LocalConnection(ConnectionBase):
             if self.unrooted:
                 raise TargetStableError('unrooted')
             password = self._get_password()
-            command = "echo {} | sudo -p ' ' -S -- sh -c {}".format(quote(password), quote(command))
+            command = "echo {} | sudo -k -p ' ' -S -- sh -c {}".format(quote(password), quote(command))
         ignore = None if check_exit_code else 'all'
         try:
             stdout, stderr = check_output(command, shell=True, timeout=timeout, ignore=ignore)
@@ -127,7 +127,7 @@ class LocalConnection(ConnectionBase):
             password = self._get_password()
             # The sudo prompt will add a space on stderr, but we cannot filter
             # it out here
-            command = "echo {} | sudo -p ' ' -S -- sh -c {}".format(quote(password), quote(command))
+            command = "echo {} | sudo -k -p ' ' -S -- sh -c {}".format(quote(password), quote(command))
 
         # Make sure to get a new PGID so PopenBackgroundCommand() can kill
         # all sub processes that could be started without troubles.

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -59,7 +59,7 @@ from devlib.connection import (ConnectionBase, ParamikoBackgroundCommand, PopenB
                                SSHTransferManager)
 
 
-DEFAULT_SSH_SUDO_COMMAND = "sudo -p ' ' -S -- sh -c {}"
+DEFAULT_SSH_SUDO_COMMAND = "sudo -k -p ' ' -S -- sh -c {}"
 
 
 ssh = None


### PR DESCRIPTION
Add -k to sudo invocation to avoid using cached credentials.

If cached credentials is used, sudo will not write a prompt again,
leading to the stderr fixup code to remove a char from stderr output.