### PR TITLE
connection: PopenTransferManager: Reset last_sample when we start a n…

### DIFF
--- a/devlib/connection.py
+++ b/devlib/connection.py
@@ -466,6 +466,7 @@ class PopenTransferManager(TransferManagerBase):
         if self.transfer:
             self.transfer.cancel()
             self.transfer = None
+            self.last_sample = None
 
     def isactive(self):
         size_fn = self._push_dest_size if self.direction == 'push' else self._pull_dest_size
@@ -477,6 +478,7 @@ class PopenTransferManager(TransferManagerBase):
 
     def set_transfer_and_wait(self, popen_bg_cmd):
         self.transfer = popen_bg_cmd
+        self.last_sample = None
         ret = self.transfer.wait()
 
         if ret and not self.transfer_aborted.is_set():


### PR DESCRIPTION
…ew transfer

last_sample is initialized in the PopenTransferManager constructor.
However, there is only one PopenTransferManager instance, which is
initialized during the construction of AndroidTarget.  Afterwards, the
transfer manager is reused for every file transfer, without going
through __init__().  Therefore, after pushing/pulling a big file, the
next file transfer has compares the current size to the last sample of
the previous file transfer.  This makes it believe that the transfer
is inactive.

Reinitialize last_sample every time we start a new transfer to avoid
this.