### PR TITLE
module/hotplug: Extend hotplug support with 'fail' and 'states' interfaces

### DIFF
--- a/devlib/module/hotplug.py
+++ b/devlib/module/hotplug.py
@@ -57,3 +57,23 @@ class HotplugModule(Module):
             return
         value = 1 if online else 0
         self.target.write_value(path, value)
+
+    def _get_path(self, path):
+        return self.target.path.join(self.base_path,
+            path)
+
+    def fail(self, cpu, state):
+        path = self._get_path('cpu{}/hotplug/fail'.format(cpu))
+        return self.target.write_value(path, state)
+
+    def get_state(self, cpu):
+        path = self._get_path('cpu{}/hotplug/state'.format(cpu))
+        return self.target.read_value(path)
+
+    def get_states(self):
+        path = self._get_path('hotplug/states')
+        states_string = self.target.read_value(path)
+        return dict(
+                map(str.strip, string.split(':', 1))
+                for string in states_string.strip().splitlines()
+        )


### PR DESCRIPTION
The Linux HP path is composed of a series of states the CPU has to execute
to perform a complete hotplug or hotunplug. Devlib now exposes this
information. get_state() gives the current state of a CPU. get_states()
gives the list of all the states that composes the HP path.

The Linux HP 'fail' interface allows to simulate a failure during the
hotplug path. It helps to test the rollback mechanism. Devlib exposes this
interface with the method fail().