### PR TITLE
docs: Add note to hostid about PowerPc64 devices

### DIFF
--- a/doc/target.rst
+++ b/doc/target.rst
@@ -133,6 +133,9 @@ Target
 
    A numerical id used to represent the identity of the target.
 
+   .. note:: Currently on 64-bit PowerPC devices this id will always be 0. This is
+             due to the included busybox binary being linked with musl.
+
 .. attribute:: Target.system_id
 
    A unique identifier for the system running on the target. This identifier is


### PR DESCRIPTION
Add caveat for the hostid on PowerPC64 devices due to the library
used when linking the included binary.