### PR TITLE
ssh: Raise explicit exception when SFTP is not available

### DIFF
--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -466,7 +466,13 @@ class SshConnection(SshConnectionBase):
         return self.transfer_mgr.progress_cb if self.transfer_mgr is not None else None
 
     def _get_sftp(self, timeout):
-        sftp = self.client.open_sftp()
+        try:
+            sftp = self.client.open_sftp()
+        except paramiko.ssh_exception.SSHException as e:
+            if 'EOF during negotiation' in str(e):
+                raise TargetStableError('The SSH server does not support SFTP. Please install and enable appropriate module.') from e
+            else:
+                raise
         sftp.get_channel().settimeout(timeout)
         return sftp
 


### PR DESCRIPTION
When SFTP is not available on OpenSSH, paramiko will raise a generic
exception:

    paramiko.ssh_exception.SSHException: EOF during negotiation

In order to make it easier to debug, raise a TargetStableError telling
the user to enable SFTP on their server. On OpenSSH, this means
installing the sftp subsystem and enabling it in sshd_config.