### PR TITLE
target: Make Target.push/pull work with pathlib

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -485,6 +485,9 @@ class Target(object):
 
     @call_conn
     def push(self, source, dest, as_root=False, timeout=None, globbing=False):  # pylint: disable=arguments-differ
+        source = str(source)
+        dest = str(dest)
+
         sources = glob.glob(source) if globbing else [source]
         self._prepare_xfer('push', sources, dest)
 
@@ -541,6 +544,9 @@ class Target(object):
 
     @call_conn
     def pull(self, source, dest, as_root=False, timeout=None, globbing=False):  # pylint: disable=arguments-differ
+        source = str(source)
+        dest = str(dest)
+
         if globbing:
             sources = self._expand_glob(source, as_root=as_root)
         else:


### PR DESCRIPTION
Convert paths to str() so that passing a pathlib.Path works.