### PR TITLE
ssh: Align _pull_folder to cp behavior

### DIFF
--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -558,6 +558,12 @@ class SshConnection(SshConnectionBase):
         sftp.get(src, dst, callback=self._get_progress_cb())
 
     def _pull_folder(self, sftp, src, dst):
+        if os.path.isdir(dst):
+            dst = os.path.join(
+                dst,
+                os.path.basename(src),
+            )
+
         with contextlib.suppress(FileNotFoundError):
             try:
                 shutil.rmtree(dst)


### PR DESCRIPTION
target.pull('/foo/bar', '.') is expected to create a ./bar folder on the
host, rather than pulling the content of /foo/bar/* directly in "."

This also fixes the issue of trying to delete the "." destination, which
can have very bad consequences.