### PR TITLE
host: Fix PopenBackgroundCommand stdin

### DIFF
--- a/devlib/host.py
+++ b/devlib/host.py
@@ -138,6 +138,7 @@ class LocalConnection(ConnectionBase):
             command,
             stdout=stdout,
             stderr=stderr,
+            stdin=subprocess.PIPE,
             shell=True,
             preexec_fn=preexec_fn,
         )

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -600,7 +600,7 @@ def adb_background_shell(conn, command,
     adb_cmd = get_adb_command(device, 'shell', adb_server)
     full_command = '{} {}'.format(adb_cmd, quote(command))
     logger.debug(full_command)
-    p = subprocess.Popen(full_command, stdout=stdout, stderr=stderr, shell=True)
+    p = subprocess.Popen(full_command, stdout=stdout, stderr=stderr, stdin=subprocess.PIPE, shell=True)
 
     # Out of band PID lookup, to avoid conflicting needs with stdout redirection
     find_pid = '{} ps -A -o pid,args | grep {}'.format(conn.busybox, quote(uuid_var))


### PR DESCRIPTION
The Popen object created for background command currently has no stdin
pipe, preventing the user from writing to it (it will be None instead of
being a file-like object).

Fix that by passing stdin=subprocess.PIPE to Popen constructor.