### PR TITLE
target: Fix fallback path for kernel config loading

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -249,9 +249,9 @@ class Target(object):
         try:
             return KernelConfig(self.execute('zcat /proc/config.gz'))
         except TargetStableError:
-            for path in ['/boot/config', '/boot/config-$(uname -r)']:
+            for path in ['/boot/config-$({} uname -r)'.format(self.busybox), '/boot/config']:
                 try:
-                    return KernelConfig(self.execute('cat {}'.format(quote(path))))
+                    return KernelConfig(self.execute('cat {}'.format(path)))
                 except TargetStableError:
                     pass
         return KernelConfig('')


### PR DESCRIPTION
The main path is reading /proc/config.gz. If it does not exists, the
following paths are tested:
'/boot/config', '/boot/config-$(uname -r)'

Since the 2nd path contains a command to be executed, remove quoting of
the path when using "cat".