### PR TITLE
ftrace: Do not memoize FtraceCollector.available_events

### DIFF
--- a/devlib/collector/ftrace.py
+++ b/devlib/collector/ftrace.py
@@ -203,7 +203,6 @@ class FtraceCollector(CollectorBase):
         return self.target.read_value(self.available_tracers_file).split(' ')
 
     @property
-    @memoized
     def available_events(self):
         """
         List of ftrace events supported by the target's kernel.


### PR DESCRIPTION
ftrace events can be added and removed dynamically by kernel modules, so
they cannot be memoized.