### PR TITLE
target: Replace Target.__copy__ by __getstate__

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -336,13 +336,14 @@ class Target(object):
         if connect:
             self.connect()
 
-    def __copy__(self):
-        new = self.__class__.__new__(self.__class__)
-        new.__dict__ = self.__dict__.copy()
-        # Avoid sharing the connection instance with the original target, so
-        # that each target can live its own independent life
-        del new.__dict__['_conn']
-        return new
+    def __getstate__(self):
+        return {
+            k: v
+            for k, v in self.__dict__.items()
+            # Avoid sharing the connection instance with the original target,
+            # so that each target can live its own independent life
+            if k != '_conn'
+        }
 
     # connection and initialization
 


### PR DESCRIPTION
`__getstate__` is also used by the copy module, but allows pickling the
class as well. This is useful when using the multiprocessing API, which
requires pickling the Target object to send it to the new process.


Background: I'm making use of the Linux's user and mount namespace in order to compile kernel modules (so I can mount overlayfs and use chroot into Alpine without requiring sudo), which require using a separate process. The process unfortunately needs to interact with the target, which means the Target object needs to be pickled and sent to it on a pipe.