### PR TITLE
android: Fix adb background command PID detection

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -257,6 +257,7 @@ def redirect_streams(stdout, stderr, command):
     def redirect(stream, redirection):
         if stream == subprocess.DEVNULL:
             suffix = '{}/dev/null'.format(redirection)
+            stream = subprocess.PIPE
         elif stream == subprocess.STDOUT:
             suffix = '{}&1'.format(redirection)
             # Indicate that there is nothing to monitor for stderr anymore


### PR DESCRIPTION
Sometimes the reported PID for a background command would be reported
incorrectly. This was due to an assumption that the lowest PID
was always the command we were looking for, however this is not always
true and PID's could be recycled resulting in the PID of the search
command being reported instead.

To avoid this, filter the reported processes on the the grep command
itself to eliminate matching processes in the system and improve
detection of the PID of the desired background process.