### PR TITLE
target: Allow relative path for for push/pull

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -517,7 +517,7 @@ class Target(object):
             src_excep = HostError
             src_path_kind = host_paths_kind
 
-            dst_mkdir = once(self.makedirs)
+            _dst_mkdir = once(self.makedirs)
             dst_path_join = self.path.join
             dst_paths_kind = target_paths_kind
             dst_remove_file = once(functools.partial(self.remove, as_root=as_root))
@@ -525,12 +525,17 @@ class Target(object):
             src_excep = TargetStableError
             src_path_kind = target_paths_kind
 
-            dst_mkdir = once(functools.partial(os.makedirs, exist_ok=True))
+            _dst_mkdir = once(functools.partial(os.makedirs, exist_ok=True))
             dst_path_join = os.path.join
             dst_paths_kind = host_paths_kind
             dst_remove_file = once(os.remove)
         else:
             raise ValueError('Unknown action "{}"'.format(action))
+
+        # Handle the case where path is None
+        def dst_mkdir(path):
+            if path:
+                _dst_mkdir(path)
 
         def rewrite_dst(src, dst):
             new_dst = dst_path_join(dst, os.path.basename(src))


### PR DESCRIPTION
Currently, it is not possible to push/pull files with a relative path. This
is due to the basename resolution. Fix this beahviour.