### PR TITLE
modules/sched: Use correct permissions to read debugfs

### DIFF
--- a/devlib/module/sched.py
+++ b/devlib/module/sched.py
@@ -329,7 +329,7 @@ class SchedProcFSData(SchedProcFSNode):
         except TargetStableError:
             return False
 
-        cpus = target.list_directory(path)
+        cpus = target.list_directory(path, as_root=target.is_rooted)
         if not cpus:
             return False
 


### PR DESCRIPTION
Use target.list_directory(as_root=target.is_rooted) instead of doing it
as a normal user for paths in /sys/kernel/debug. Since this
list_directory() call can be used with multiple path, we do not force
as_root=True but we increase the chance of it working.