### PR TITLE
module/cgroups: Skip disabled cgroup controllers

### DIFF
--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -411,7 +411,7 @@ class CgroupsModule(Module):
         for line in self.target.execute('{} cat /proc/cgroups'\
                 .format(self.target.busybox), as_root=self.target.is_rooted).splitlines()[1:]:
             line = line.strip()
-            if not line or line.startswith('#'):
+            if not line or line.startswith('#') or line.endswith('0'):
                 continue
             name, hierarchy, num_cgroups, enabled = line.split()
             subsystems.append(CgroupSubsystemEntry(name,


### PR DESCRIPTION
Currently the cgroups module will pull all available controllers from
/proc/cgroups and then try to mount them, including the disabled ones.
This will result in the entire mount failing.

Lines in /proc/cgroups ending in 0 correspond to disabled controllers.
Filtering those out solves the issue.