### PR TITLE
devlib.target: Fix AndroidTarget unpickle

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1798,7 +1798,7 @@ class AndroidTarget(Target):
         }
 
     def __setstate__(self, dct):
-        self.__dict__.update(dct)
+        super().__setstate__(dct)
         self._init_logcat_lock()
 
     @asyn.asyncf


### PR DESCRIPTION
Fix __setstate__ to call super().__setstate__ in order to handle the
generic part of the deserialization.