### PR TITLE
Mitigate CVE-2007-4995

### DIFF
--- a/devlib/module/android.py
+++ b/devlib/module/android.py
@@ -22,7 +22,7 @@ import tempfile
 from devlib.module import FlashModule
 from devlib.exception import HostError
 from devlib.utils.android import fastboot_flash_partition, fastboot_command
-from devlib.utils.misc import merge_dicts
+from devlib.utils.misc import merge_dicts, safe_extract
 
 
 class FastbootFlashModule(FlashModule):
@@ -86,7 +86,7 @@ class FastbootFlashModule(FlashModule):
         self._validate_image_bundle(image_bundle)
         extract_dir = tempfile.mkdtemp()
         with tarfile.open(image_bundle) as tar:
-            tar.extractall(path=extract_dir)
+            safe_extract(tar, path=extract_dir)
             files = [tf.name for tf in tar.getmembers()]
             if self.partitions_file_name not in files:
                 extract_dir = os.path.join(extract_dir, files[0])

--- a/devlib/module/vexpress.py
+++ b/devlib/module/vexpress.py
@@ -21,6 +21,7 @@ from subprocess import CalledProcessError
 
 from devlib.module import HardRestModule, BootModule, FlashModule
 from devlib.exception import TargetError, TargetStableError, HostError
+from devlib.utils.misc import safe_extract
 from devlib.utils.serial_port import open_serial_connection, pulse_dtr, write_characters
 from devlib.utils.uefi import UefiMenu, UefiConfig
 from devlib.utils.uboot import UbootMenu
@@ -354,7 +355,7 @@ class VersatileExpressFlashModule(FlashModule):
         validate_image_bundle(bundle)
         self.logger.debug('Extracting {} into {}...'.format(bundle, self.vemsd_mount))
         with tarfile.open(bundle) as tar:
-            tar.extractall(self.vemsd_mount)
+            safe_extract(tar, self.vemsd_mount)
 
     def _overlay_images(self, images):
         for dest, src in images.items():

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -61,7 +61,7 @@ from devlib.utils.misc import memoized, isiterable, convert_new_lines, groupby_v
 from devlib.utils.misc import commonprefix, merge_lists
 from devlib.utils.misc import ABI_MAP, get_cpu_name, ranges_to_list
 from devlib.utils.misc import batch_contextmanager, tls_property, _BoundTLSProperty, nullcontext
-from devlib.utils.misc import strip_bash_colors
+from devlib.utils.misc import strip_bash_colors, safe_extract
 from devlib.utils.types import integer, boolean, bitmask, identifier, caseless_string, bytes_regex
 import devlib.utils.asyn as asyn
 
@@ -827,7 +827,7 @@ class Target(object):
             await self.pull.asyn(tar_file_name, tmpfile)
             # Decompress
             with tarfile.open(tmpfile, 'r') as f:
-                f.extractall(outdir)
+                safe_extract(f, outdir)
             os.remove(tmpfile)
 
     # execution


### PR DESCRIPTION
Prevent potential directory path traversal attacks (see https://www.trellix.com/en-us/about/newsroom/stories/research/tarfile-exploiting-the-world.html)

This is an alternative to the automatically generated https://github.com/ARM-software/devlib/pull/607 without code duplication.