### PR TITLE
Import quote() form shlex rather than pipes

### DIFF
--- a/devlib/collector/ftrace.py
+++ b/devlib/collector/ftrace.py
@@ -21,7 +21,7 @@ import re
 import subprocess
 import sys
 import contextlib
-from pipes import quote
+from shlex import quote
 
 from devlib.collector import (CollectorBase, CollectorOutput,
                               CollectorOutputEntry)

--- a/devlib/host.py
+++ b/devlib/host.py
@@ -20,7 +20,7 @@ import subprocess
 import logging
 from distutils.dir_util import copy_tree
 from getpass import getpass
-from pipes import quote
+from shlex import quote
 
 from devlib.exception import (
     TargetTransientError, TargetStableError,

--- a/devlib/instrument/acmecape.py
+++ b/devlib/instrument/acmecape.py
@@ -23,7 +23,7 @@ import shlex
 from fcntl import fcntl, F_GETFL, F_SETFL
 from string import Template
 from subprocess import Popen, PIPE, STDOUT
-from pipes import quote
+from shlex import quote
 
 from devlib import Instrument, CONTINUOUS, MeasurementsCsv
 from devlib.exception import HostError

--- a/devlib/instrument/arm_energy_probe.py
+++ b/devlib/instrument/arm_energy_probe.py
@@ -32,12 +32,12 @@
 # pylint: disable=W0613,E1101,access-member-before-definition,attribute-defined-outside-init
 from __future__ import division
 import os
-import subprocess
-import signal
-from pipes import quote
-
-import tempfile
 import shutil
+import signal
+import tempfile
+import subprocess
+from shlex import quote
+
 
 from devlib.instrument import Instrument, CONTINUOUS, MeasurementsCsv
 from devlib.exception import HostError

--- a/devlib/instrument/energy_probe.py
+++ b/devlib/instrument/energy_probe.py
@@ -19,7 +19,7 @@ import tempfile
 import struct
 import subprocess
 import sys
-from pipes import quote
+from shlex import quote
 
 from devlib.instrument import Instrument, CONTINUOUS, MeasurementsCsv
 from devlib.exception import HostError

--- a/devlib/platform/gem5.py
+++ b/devlib/platform/gem5.py
@@ -19,7 +19,7 @@ import shutil
 import time
 import types
 import shlex
-from pipes import quote
+from shlex import quote
 
 from devlib.exception import TargetStableError
 from devlib.host import PACKAGE_BIN_DIRECTORY

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -36,10 +36,10 @@ import inspect
 import itertools
 from collections import namedtuple, defaultdict
 from contextlib import contextmanager
-from pipes import quote
 from past.builtins import long
 from past.types import basestring
 from numbers import Number
+from shlex import quote
 try:
     from collections.abc import Mapping
 except ImportError:

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -35,11 +35,7 @@ import threading
 from collections import defaultdict
 from io import StringIO
 from lxml import etree
-
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
+from shlex import quote
 
 from devlib.exception import TargetTransientError, TargetStableError, HostError, TargetTransientCalledProcessError, TargetStableCalledProcessError, AdbRootError
 from devlib.utils.misc import check_output, which, ABI_MAP, redirect_streams, get_subprocess

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -47,11 +47,7 @@ try:
 except AttributeError:
     from contextlib2 import ExitStack
 
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
-
+from shlex import quote
 from past.builtins import basestring
 
 # pylint: disable=redefined-builtin
@@ -462,7 +458,7 @@ def escape_quotes(text):
     """
     Escape quotes, and escaped quotes, in the specified text.
 
-    .. note:: :func:`pipes.quote` should be favored where possible.
+    .. note:: :func:`shlex.quote` should be favored where possible.
     """
     return re.sub(r'\\("|\')', r'\\\\\1', text).replace('\'', '\\\'').replace('\"', '\\\"')
 
@@ -471,7 +467,7 @@ def escape_single_quotes(text):
     """
     Escape single quotes, and escaped single quotes, in the specified text.
 
-    .. note:: :func:`pipes.quote` should be favored where possible.
+    .. note:: :func:`shlex.quote` should be favored where possible.
     """
     return re.sub(r'\\("|\')', r'\\\\\1', text).replace('\'', '\'\\\'\'')
 
@@ -480,7 +476,7 @@ def escape_double_quotes(text):
     """
     Escape double quotes, and escaped double quotes, in the specified text.
 
-    .. note:: :func:`pipes.quote` should be favored where possible.
+    .. note:: :func:`shlex.quote` should be favored where possible.
     """
     return re.sub(r'\\("|\')', r'\\\\\1', text).replace('\"', '\\\"')
 
@@ -489,7 +485,7 @@ def escape_spaces(text):
     """
     Escape spaces in the specified text
 
-    .. note:: :func:`pipes.quote` should be favored where possible.
+    .. note:: :func:`shlex.quote` should be favored where possible.
     """
     return text.replace(' ', '\\ ')
 

--- a/devlib/utils/rendering.py
+++ b/devlib/utils/rendering.py
@@ -21,7 +21,7 @@ import tempfile
 import threading
 import time
 from collections import namedtuple
-from pipes import quote
+from shlex import quote
 
 # pylint: disable=redefined-builtin
 from devlib.exception  import WorkerThreadError, TargetNotRespondingError, TimeoutError

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -32,8 +32,8 @@ import weakref
 import select
 import copy
 import functools
-from pipes import quote
 from future.utils import raise_from
+from shlex import quote
 
 from paramiko.client import SSHClient, AutoAddPolicy, RejectPolicy
 import paramiko.ssh_exception


### PR DESCRIPTION
pipes module is deprecated since 3.11, and quote() has been available in
shlex since 3.3.

Addresses https://github.com/ARM-software/devlib/issues/609