### PR TITLE
devlib: Remove "future"

### DIFF
--- a/devlib/collector/dmesg.py
+++ b/devlib/collector/dmesg.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from __future__ import division
 import re
 from itertools import takewhile
 from datetime import timedelta

--- a/devlib/collector/ftrace.py
+++ b/devlib/collector/ftrace.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from __future__ import division
 import os
 import json
 import time

--- a/devlib/derived/energy.py
+++ b/devlib/derived/energy.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import division
 from collections import defaultdict
 
 from devlib.derived import DerivedMeasurements, DerivedMetric

--- a/devlib/derived/fps.py
+++ b/devlib/derived/fps.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from __future__ import division
 import os
 
 try:

--- a/devlib/instrument/__init__.py
+++ b/devlib/instrument/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import division
 import logging
 import collections
 

--- a/devlib/instrument/acmecape.py
+++ b/devlib/instrument/acmecape.py
@@ -14,7 +14,6 @@
 #
 
 #pylint: disable=attribute-defined-outside-init
-from __future__ import division
 import os
 import sys
 import time

--- a/devlib/instrument/arm_energy_probe.py
+++ b/devlib/instrument/arm_energy_probe.py
@@ -30,7 +30,6 @@
 
 
 # pylint: disable=W0613,E1101,access-member-before-definition,attribute-defined-outside-init
-from __future__ import division
 import os
 import shutil
 import signal

--- a/devlib/instrument/energy_probe.py
+++ b/devlib/instrument/energy_probe.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import division
 import os
 import signal
 import tempfile

--- a/devlib/instrument/frames.py
+++ b/devlib/instrument/frames.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from __future__ import division
 import os
 
 from devlib.instrument import (Instrument, CONTINUOUS,

--- a/devlib/instrument/gem5power.py
+++ b/devlib/instrument/gem5power.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import division
-
 from devlib.platform.gem5 import Gem5SimulationPlatform
 from devlib.instrument import Instrument, CONTINUOUS, MeasurementsCsv
 from devlib.exception import TargetStableError

--- a/devlib/instrument/hwmon.py
+++ b/devlib/instrument/hwmon.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import division
 import re
 
 from devlib.instrument import Instrument, Measurement, INSTANTANEOUS

--- a/devlib/instrument/netstats/__init__.py
+++ b/devlib/instrument/netstats/__init__.py
@@ -18,8 +18,7 @@ import re
 import tempfile
 from datetime import datetime
 from collections import defaultdict
-
-from future.moves.itertools import zip_longest
+from itertools import zip_longest
 
 from devlib.instrument import Instrument, MeasurementsCsv, CONTINUOUS
 from devlib.exception import TargetStableError, HostError

--- a/devlib/platform/arm.py
+++ b/devlib/platform/arm.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import division
 import os
 import sys
 import tempfile

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -18,7 +18,6 @@
 Miscellaneous functions that don't fit anywhere else.
 
 """
-from __future__ import division
 from contextlib import contextmanager
 from functools import partial, reduce, wraps
 from itertools import groupby

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -32,7 +32,6 @@ import weakref
 import select
 import copy
 import functools
-from future.utils import raise_from
 from shlex import quote
 
 from paramiko.client import SSHClient, AutoAddPolicy, RejectPolicy
@@ -848,8 +847,8 @@ class TelnetConnection(SshConnectionBase):
         try:
             check_output(command, timeout=timeout, shell=True)
         except subprocess.CalledProcessError as e:
-            raise_from(HostError("Failed to copy file with '{}'. Output:\n{}".format(
-                command_redacted, e.output)), None)
+            msg = f"Failed to copy file with '{command_redacted}'. Output:\n{e.output}"
+            raise HostError(msg) from None
         except TimeoutError as e:
             raise TimeoutError(command_redacted, e.output)
 

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ params = dict(
         'paramiko', # SSH connection
         'scp', # SSH connection file transfers
         'wrapt',  # Basic for construction of decorator functions
-        'future', # Python 2-3 compatibility
         'numpy',
         'pandas',
         'lxml', # More robust xml parsing


### PR DESCRIPTION
Remove the "future" dependency as devlib does not support Python 2 anymore.

Also remove the "from __future__ import division" as this is the default in Python 3.

Fixes #612 