### PR TITLE
utils/android: Fix adb_root() exceptions

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -411,11 +411,11 @@ class AdbConnection(ConnectionBase):
             if 'adbd is already running as root' in e.output:
                 pass
             else:
-                raise
+                raise AdbRootError(str(e)) from e
         else:
             # Check separately as this does not cause a error exit code.
             if 'cannot run as root in production builds' in output:
-                raise TargetStableError(output)
+                raise AdbRootError(output)
         AdbConnection._connected_as_root[self.device] = enable
 
     def wait_for_device(self, timeout=30):


### PR DESCRIPTION
Ensure adb_root() always raises AdbRootError so that the caller can catch it reliably. This is especially important since adb_root() failing is ignored and simply triggers a fallback on using `su`. Android production builds refuse adb root nowadays, so it's important that adb root failures are handled well.