### PR TITLE
target: Add persistent_data_path to AndroidTarget

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1750,6 +1750,11 @@ class AndroidTarget(Target):
 
     @property
     @memoized
+    def external_storage_app_dir(self):
+        return self.path.join(self.external_storage, 'Android', 'data')
+
+    @property
+    @memoized
     def screen_resolution(self):
         output = self.execute('dumpsys window displays')
         match = ANDROID_SCREEN_RESOLUTION_REGEX.search(output)


### PR DESCRIPTION
Some apps, such as Unity-based applications, can store some files in their 'persistent data path' which is usually under '/storage/emulated/0/Android/data'. Add a handle to easily access the path within AndroidTarget in the same way as package_data_directory currently is accessible.