### PR TITLE
ftrace: Avoid repeated available events query

### DIFF
--- a/devlib/collector/ftrace.py
+++ b/devlib/collector/ftrace.py
@@ -137,10 +137,11 @@ class FtraceCollector(CollectorBase):
                 for _event in events
             )
 
+        available_events = self.available_events
         unavailable_events = [
             event
             for event in self.events
-            if not event_is_in_list(event, self.available_events)
+            if not event_is_in_list(event, available_events)
         ]
         if unavailable_events:
             message = 'Events not available for tracing: {}'.format(


### PR DESCRIPTION
FtraceCollector.available_events is not memoized anymore as the set of events supported by the target can change dynamically (e.g. loading a kernel module).

This means that calling self.available_events is somewhat expensive, so avoid doing it in a loop. Instead, save the events in a variable and reuse it in the function to save a substantial amount of time.