### PR TITLE
connection: Terminate background commands on close()

### DIFF
--- a/devlib/connection.py
+++ b/devlib/connection.py
@@ -120,6 +120,10 @@ class BackgroundCommand(ABC):
     Instances of this class can be used as context managers, with the same
     semantic as :class:`subprocess.Popen`.
     """
+
+    def __init__(self, conn):
+        self.conn = conn
+
     @abstractmethod
     def send_signal(self, sig):
         """
@@ -235,7 +239,8 @@ class PopenBackgroundCommand(BackgroundCommand):
     :class:`subprocess.Popen`-based background command.
     """
 
-    def __init__(self, popen):
+    def __init__(self, conn, popen):
+        super().__init__(conn=conn)
         self.popen = popen
 
     def send_signal(self, sig):
@@ -291,9 +296,9 @@ class ParamikoBackgroundCommand(BackgroundCommand):
     :mod:`paramiko`-based background command.
     """
     def __init__(self, conn, chan, pid, as_root, cmd, stdin, stdout, stderr, redirect_thread):
+        super().__init__(conn=conn)
         self.chan = chan
         self.as_root = as_root
-        self.conn = conn
         self._pid = pid
         self._stdin = stdin
         self._stdout = stdout
@@ -454,7 +459,7 @@ class AdbBackgroundCommand(BackgroundCommand):
     """
 
     def __init__(self, conn, adb_popen, pid, as_root):
-        self.conn = conn
+        super().__init__(conn=conn)
         self.as_root = as_root
         self.adb_popen = adb_popen
         self._pid = pid

--- a/devlib/host.py
+++ b/devlib/host.py
@@ -141,7 +141,7 @@ class LocalConnection(ConnectionBase):
             shell=True,
             preexec_fn=preexec_fn,
         )
-        bg_cmd = PopenBackgroundCommand(popen)
+        bg_cmd = PopenBackgroundCommand(self, popen)
         self._current_bg_cmds.add(bg_cmd)
         return bg_cmd
 

--- a/devlib/host.py
+++ b/devlib/host.py
@@ -142,7 +142,6 @@ class LocalConnection(ConnectionBase):
             preexec_fn=preexec_fn,
         )
         bg_cmd = PopenBackgroundCommand(self, popen)
-        self._current_bg_cmds.add(bg_cmd)
         return bg_cmd
 
     def _close(self):

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -334,7 +334,12 @@ class AdbConnection(ConnectionBase):
             adb_command(self.device, command, timeout=timeout, adb_server=self.adb_server)
         else:
             with self.transfer_mgr.manage(sources, dest, action):
-                bg_cmd = adb_command_background(self.device, command, adb_server=self.adb_server)
+                bg_cmd = adb_command_background(
+                    device=self.device,
+                    conn=self,
+                    command=command,
+                    adb_server=self.adb_server
+                )
                 self.transfer_mgr.set_transfer_and_wait(bg_cmd)
 
     # pylint: disable=unused-argument
@@ -692,11 +697,11 @@ def adb_command(device, command, timeout=None, adb_server=None):
     return output
 
 
-def adb_command_background(device, command, adb_server=None):
+def adb_command_background(device, conn, command, adb_server=None):
     full_command = get_adb_command(device, command, adb_server)
     logger.debug(full_command)
-    proc = get_subprocess(full_command, shell=True)
-    cmd = PopenBackgroundCommand(proc)
+    popen = get_subprocess(full_command, shell=True)
+    cmd = PopenBackgroundCommand(conn=conn, popen=popen)
     return cmd
 
 

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -368,7 +368,6 @@ class AdbConnection(ConnectionBase):
         if as_root and self.connected_as_root:
             as_root = False
         bg_cmd = self._background(command, stdout, stderr, as_root)
-        self._current_bg_cmds.add(bg_cmd)
         return bg_cmd
 
     def _background(self, command, stdout, stderr, as_root):

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -696,9 +696,6 @@ class SshConnection(SshConnectionBase):
     def _close(self):
         logger.debug('Logging out {}@{}'.format(self.username, self.host))
         with _handle_paramiko_exceptions():
-            bg_cmds = set(self._current_bg_cmds)
-            for bg_cmd in bg_cmds:
-                bg_cmd.close()
             self.client.close()
 
     def _execute_command(self, command, as_root, log, timeout, executor):

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -553,10 +553,7 @@ class SshConnection(SshConnectionBase):
 
     def background(self, command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, as_root=False):
         with _handle_paramiko_exceptions(command):
-            bg_cmd = self._background(command, stdout, stderr, as_root)
-
-        self._current_bg_cmds.add(bg_cmd)
-        return bg_cmd
+            return self._background(command, stdout, stderr, as_root)
 
     def _background(self, command, stdout, stderr, as_root):
         orig_command = command


### PR DESCRIPTION
Ensure all background commands are terminated before we close the connection.

This PR adds tracking of all outstanding BackgroundCommand inside `ConnectionBase._current_bg_cmds`. This attribute is changed from WeakSet() to set(), and the BackgroundCommand themselves deregister themselves when they terminate. This allows properly canceling _all_ outstanding_ bg command when the connection is closed.

BackgroundCommand.__init__ polls current bg cmds of its connection to reap any terminated commands, so that APIs that leak objects like the change introduced by this PR:
https://github.com/ARM-software/devlib/pull/624
or any other non-careful user does not result in endless leak of associated resources.