### PR TITLE
connection: Make BackgroundCommand.wait() return non-None

### DIFF
--- a/devlib/connection.py
+++ b/devlib/connection.py
@@ -170,7 +170,7 @@ class BackgroundCommand(ABC):
         :type signal: signal.Signals
         """
         try:
-            self._send_signal(signal.SIGKILL)
+            return self._send_signal(signal.SIGKILL)
         finally:
             # Deregister if the command has finished
             self.poll()
@@ -188,7 +188,7 @@ class BackgroundCommand(ABC):
         """
         try:
             if self.poll() is None:
-                self._cancel(kill_timeout=kill_timeout)
+                return self._cancel(kill_timeout=kill_timeout)
         finally:
             self._deregister()
 
@@ -208,7 +208,7 @@ class BackgroundCommand(ABC):
         Block until the background command completes, and return its exit code.
         """
         try:
-            self._wait()
+            return self._wait()
         finally:
             self._deregister()
 


### PR DESCRIPTION
Lack of return statement in wait() was making it return None instead of the exit code. Add appropriate return statement in wait() and other function to ensure return value is not lost.