### PR TITLE
utils/android: Use LC_ALL for adb commands

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -699,7 +699,7 @@ def get_adb_command(device, command, adb_server=None):
     if adb_server != None:
         device_string = ' -H {}'.format(adb_server)
     device_string += ' -s {}'.format(device) if device else ''
-    return "adb{} {}".format(device_string, command)
+    return "LC_ALL=C adb{} {}".format(device_string, command)
 
 
 def adb_command(device, command, timeout=None, adb_server=None):


### PR DESCRIPTION
Ensures that adb commands are executed with english locale since we sometimes match on the output.

Needs testing but should fix https://github.com/ARM-software/devlib/issues/599