### PR TITLE
Cleanup module load

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -130,13 +130,7 @@ class Target(object):
     os = None
     system_id = None
 
-    default_modules = [
-        'hotplug',
-        'cpufreq',
-        'cpuidle',
-        'cgroups',
-        'hwmon',
-    ]
+    default_modules = []
 
     @property
     def core_names(self):


### PR DESCRIPTION
Cleanup module code to improve robustness, modularity and enable lazy loading of modules.

The main features are:
* More checks (e.g. it is now impossible to add multiple modules of the same kind)
* Predictable Target.modules content: it used to be a mix of str and dict, now it's str only
* Modules don't have to be declared in `Target(modules=...)` anymore to be used. They can simply be accessed and that will load them lazily. Passing `Target(modules=[{mod: None}])` will prevent loading of the module in all circumstances, including lazily.

For now, modules passed to `Target(modules=...)` will be eagerly loaded, but that could be changed quite easily to enable full lazy loading if we wanted.

On top of that, the list of default modules is made empty. This fixes https://github.com/ARM-software/devlib/issues/611 as nothing will be loaded by default, but existing code will keep working thanks to lazy loading.