### PR TITLE
utils.rendering: Fix activity matching

### DIFF
--- a/devlib/utils/rendering.py
+++ b/devlib/utils/rendering.py
@@ -131,9 +131,18 @@ class SurfaceFlingerFrameCollector(FrameCollector):
         self.header = header or SurfaceFlingerFrame._fields
 
     def collect_frames(self, wfh):
-        for activity in self.list():
-            if activity == self.view:
-                wfh.write(self.get_latencies(activity).encode('utf-8'))
+        activities = [a for a in self.list() if a.startswith(self.view)]
+
+        if len(activities) > 1:
+            raise ValueError(
+                "More than one activity matching view '{}' was found: {}".format(self.view, activities)
+            )
+
+        if not activities:
+            logger.warning("No activities matching view '{}' were found".format(self.view))
+
+        for activity in activities:
+            wfh.write(self.get_latencies(activity).encode('utf-8'))
 
     def clear(self):
         self.target.execute('dumpsys SurfaceFlinger --latency-clear ')


### PR DESCRIPTION
Change the SurfaceFlingerFrameCollector to match activities by prefix instead of looking for an exact match. This will allow to account for activities with variable suffixes.
Raise an error if more than one activity matches the provided view.

Suggested-by: Andriani Mappoura <andriani.mappoura@arm.com>