### PR TITLE
AndroidTarget: Skip ungrantable Android permission

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -2092,6 +2092,8 @@ class AndroidTarget(Target):
                 pass # Ignore if not requested
             elif 'Operation not allowed' in e.message:
                 pass # Ignore if not allowed
+            elif 'is managed by role' in e.message:
+                pass # Ignore if cannot be granted
             else:
                 raise
 


### PR DESCRIPTION
Don't throw an error if attempting to grant a permission that is not manageable.  
Reported in https://github.com/ARM-software/workload-automation/issues/1234 & https://github.com/ARM-software/workload-automation/issues/1212