### PR TITLE
utils/ssh: Fix SSHTransferHandle when using SCP

### DIFF
--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -525,7 +525,9 @@ class SshConnection(SshConnectionBase):
 
         # No timeout
         elif self.use_scp:
-            scp = self._get_scp(timeout, callback=handle.progress_cb)
+            def progress_cb(*args, **kwargs):
+                return handle.progress_cb(*args, **kwargs)
+            scp = self._get_scp(timeout, callback=progress_cb)
             handle, cm = make_handle(scp)
 
             scp_cmd = getattr(scp, 'put' if action == 'push' else 'get')


### PR DESCRIPTION
Using SSHConnection(use_scp=True) lead to an exception:

    UnboundLocalError: local variable 'handle' referenced before assignment

This is cause by some (false) cyclic dependency between initialization of SSHTransferHandle and creation of the SCPClient. We can fix that by adding a level of indirection to tie together both objects.