### PR TITLE
ftrace: Do not read-verify buffer_size_kb value

### DIFF
--- a/devlib/collector/ftrace.py
+++ b/devlib/collector/ftrace.py
@@ -251,7 +251,7 @@ class FtraceCollector(CollectorBase):
         if top_buffer_size:
             self.target.write_value(
                 self.target.path.join(self.tracing_path, 'buffer_size_kb'),
-                top_buffer_size,
+                top_buffer_size, verify=False
             )
 
         if self.functions:


### PR DESCRIPTION
The sysfs documentation mentions that the value written to buffer_size_kb ftrace field may be rounded up.
So skip the verify loop on this field.

The case we are worried about, a requested buffer
size that the target cannot fulfill is caught anyway, as the sysfs write returns with an error that is caught.