### PR TITLE
UIBenchJankTests: modification to support Android 12/14 versions

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -231,12 +231,15 @@ class ApkInfo(object):
             parser = etree.XMLParser(encoding='utf-8', recover=True)
             xml_tree = etree.parse(StringIO(dump), parser)
 
-            package = next((i for i in xml_tree.iter('package')
-                           if i.attrib['name'] == self.package), None)
+            package = []
+            for i in xml_tree.iter('package'):
+                if i.attrib['name'] == self.package:
+                    package.append(i)
 
-            self._methods = [(meth.attrib['name'], klass.attrib['name'])
-                             for klass in package.iter('class')
-                             for meth in klass.iter('method')] if package else []
+            for elem in package:
+                self._methods.extend([(meth.attrib['name'], klass.attrib['name']) 
+                                      for klass in elem.iter('class') 
+                                      for meth in klass.iter('method')])
         return self._methods
 
     def _run(self, command):


### PR DESCRIPTION
dex file search for the package name is modified. In the apk, package name stated twice and the second one includes the tests information. Tested with other benchmarks (geekbench,pcmark,jankbench in Android 12) as well.