### PR TITLE
[Android] Fix use-before-initialization during initialization of ApkInfo

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -148,11 +148,11 @@ class ApkInfo(object):
         self._apk_path = None
         self._activities = None
         self._methods = None
-        if path:
-            self.parse(path)
-
         self._aapt = _ANDROID_ENV.get_env('aapt')
         self._aapt_version = _ANDROID_ENV.get_env('aapt_version')
+
+        if path:
+            self.parse(path)
 
     # pylint: disable=too-many-branches
     def parse(self, apk_path):


### PR DESCRIPTION
I noticed the following errors during invocation of uibench/uibenchjanktests:

     job:     Initializing job wk1 (uibench) [1]
  signal:         Sending before-workload-initialized from wk1 (uibench) [1]
     apk:         Resolving package on host system
resolver:         Resolving <<Workload uibench>'s apk 14>
resolver:         Trying user.get
  signal:         Sending error-logged from <ErrorSignalHandler (DEBUG)>
  signal:         Disconnecting <bound method Executor._error_signalled_callback of executor> from error-logged(<class 'louie.sender.Any'>)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/signal.py", line 324, in wrap
  signal:             yield
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/job.py", line 97, in initialize
  signal:             self.workload.initialize(context)
  signal:           File "/repos/lisa/external/workload-automation/wa/utils/exec_control.py", line 83, in wrapper
  signal:             return method(*args, **kwargs)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/workload.py", line 305, in initialize
  signal:             self.apk.initialize(context)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/workload.py", line 717, in initialize
  signal:             self.resolve_package(context)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/workload.py", line 734, in resolve_package
  signal:             self.resolve_package_from_host(context)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/workload.py", line 774, in resolve_package_from_host
  signal:             apk_file = context.get_resource(ApkFile(self.owner,
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/execution.py", line 197, in get_resource
  signal:             result = self.resolver.get(resource, strict)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/resource.py", line 268, in get
  signal:             result = source(resource)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/getters.py", line 139, in get
  signal:             return get_from_location(directory, resource)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/getters.py", line 106, in get_from_location
  signal:             return get_generic_resource(resource, files)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/getters.py", line 63, in get_generic_resource
  signal:             if resource.match(f):
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/resource.py", line 165, in match
  signal:             uiauto_matches = uiauto_test_matches(path, self.uiauto)
  signal:           File "/repos/lisa/external/workload-automation/wa/framework/resource.py", line 335, in uiauto_test_matches
  signal:             info = get_cacheable_apk_info(path)
  signal:           File "/repos/lisa/external/workload-automation/wa/utils/android.py", line 192, in get_cacheable_apk_info
  signal:             info = ApkInfo(path)
  signal:           File "/repos/lisa/external/workload-automation/wa/utils/android.py", line 116, in __init__
  signal:             super().__init__(path)
  signal:           File "/repos/lisa/external/devlib/devlib/utils/android.py", line 152, in __init__
  signal:             self.parse(path)
  signal:           File "/repos/lisa/external/devlib/devlib/utils/android.py", line 159, in parse
  signal:             output = self._run([self._aapt, 'dump', 'badging', apk_path])
  signal:
  signal:         Sending error-logged from <ErrorSignalHandler (DEBUG)>
  signal:         AttributeError('ApkInfo' object has no attribute '_aapt')
  signal:         Sending after-workload-initialized from wk1 (uibench) [1]
  signal: Sending error-logged from <ErrorSignalHandler (DEBUG)>
  runner: Skipping remaining jobs due to "'ApkInfo' object has no attribute '_aapt'".

This is due to the fact we might call self.parse in ApkInfo::__init__, if the path variable is set to a non-empty value, but the initialization of both self._aapt and self._aapt_version is after this call.

Fix this by moving the initialization of both variables before the call to self.parse.