### PR TITLE
Read target connection settings from a YAML file

### DIFF
--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -294,6 +294,10 @@ class AdbConnection(ConnectionBase):
             total_transfer_timeout=total_transfer_timeout,
             transfer_poll_period=transfer_poll_period,
         )
+
+        self.logger.debug('server=%s port=%s device=%s as_root=%s',
+                          adb_server, adb_port, device, adb_as_root)
+
         self.timeout = timeout if timeout is not None else self.default_timeout
         if device is None:
             device = adb_get_device(timeout=timeout, adb_server=adb_server, adb_port=adb_port)
@@ -545,9 +549,9 @@ def adb_connect(device, timeout=None, attempts=MAX_ATTEMPTS, adb_server=None, ad
             break
         time.sleep(10)
     else:  # did not connect to the device
-        message = 'Could not connect to {}'.format(device or 'a device')
+        message = f'Could not connect to {device or "a device"} at {adb_server}:{adb_port}'
         if output:
-            message += '; got: "{}"'.format(output)
+            message += f'; got: {output}'
         raise HostError(message)
 
 

--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -23,6 +23,7 @@ from functools import partial, reduce, wraps
 from itertools import groupby
 from operator import itemgetter
 from weakref import WeakSet
+from ruamel.yaml import YAML
 
 import ctypes
 import logging
@@ -588,6 +589,30 @@ class LoadSyntaxError(Exception):
     def __str__(self):
         message = 'Syntax Error in {}, line {}:\n\t{}'
         return message.format(self.filepath, self.lineno, self.message)
+
+
+def load_struct_from_yaml(filepath):
+    """
+    Parses a config structure from a YAML file.
+    The structure should be composed of basic Python types.
+
+    :param filepath: Input file which contains YAML data.
+    :type filepath: str
+
+    :raises LoadSyntaxError: if there is a syntax error in YAML data.
+
+    :return: A dictionary which contains parsed YAML data
+    :rtype: Dict
+    """
+
+    try:
+        yaml = YAML(typ='safe', pure=True)
+        with open(filepath, 'r', encoding='utf-8') as file_handler:
+            return yaml.load(file_handler)
+    except yaml.YAMLError as ex:
+        message = ex.message if hasattr(ex, 'message') else ''
+        lineno = ex.problem_mark.line if hasattr(ex, 'problem_mark') else None
+        raise LoadSyntaxError(message, filepath=filepath, lineno=lineno) from ex
 
 
 RAND_MOD_NAME_LEN = 30

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ params = dict(
         'lxml', # More robust xml parsing
         'nest_asyncio', # Allows running nested asyncio loops
         'future', # for the "past" Python package
+        'ruamel.yaml >= 0.15.72', # YAML formatted config parsing
     ],
     extras_require={
         'daq': ['daqpower>=2'],

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ params = dict(
         'wrapt',  # Basic for construction of decorator functions
         'numpy',
         'pandas',
+        'pytest',
         'lxml', # More robust xml parsing
         'nest_asyncio', # Allows running nested asyncio loops
         'future', # for the "past" Python package

--- a/tests/target_configs.yaml
+++ b/tests/target_configs.yaml
@@ -1,0 +1,5 @@
+LocalLinuxTarget:
+  entry-0:
+    connection_settings:
+      unrooted: True
+

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -14,35 +14,63 @@
 # limitations under the License.
 #
 
+"""Module for testing targets."""
+
 import os
 import shutil
 import tempfile
-from unittest import TestCase
+from pprint import pp
+import pytest
 
 from devlib import LocalLinuxTarget
+from devlib.utils.misc import load_struct_from_yaml
 
 
-class TestReadTreeValues(TestCase):
+def build_targets():
+    """Read targets from a YAML formatted config file"""
 
-    def test_read_multiline_values(self):
-        data = {
-            'test1': '1',
-            'test2': '2\n\n',
-            'test3': '3\n\n4\n\n',
-        }
+    config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'target_configs.yaml')
 
-        tempdir = tempfile.mkdtemp(prefix='devlib-test-')
-        for key, value in data.items():
-            path = os.path.join(tempdir, key)
-            with open(path, 'w') as wfh:
-                wfh.write(value)
+    target_configs = load_struct_from_yaml(config_file)
+    if target_configs is None:
+        raise ValueError(f'{config_file} looks empty!')
 
-        t = LocalLinuxTarget(connection_settings={'unrooted': True})
-        raw_result = t.read_tree_values_flat(tempdir)
-        result = {os.path.basename(k): v for k, v in raw_result.items()}
+    targets = []
 
-        shutil.rmtree(tempdir)
+    if target_configs.get('LocalLinuxTarget') is not None:
+        print('> LocalLinux targets:')
+        for entry in target_configs['LocalLinuxTarget'].values():
+            pp(entry)
+            ll_target = LocalLinuxTarget(connection_settings=entry['connection_settings'])
+            targets.append(ll_target)
 
-        self.assertEqual({k: v.strip()
-                          for k, v in data.items()},
-                         result)
+    return targets
+
+
+@pytest.mark.parametrize("target", build_targets())
+def test_read_multiline_values(target):
+    """
+    Test Target.read_tree_values_flat()
+
+    :param target: Type of target per :class:`Target` based classes.
+    :type target: Target
+    """
+
+    data = {
+        'test1': '1',
+        'test2': '2\n\n',
+        'test3': '3\n\n4\n\n',
+    }
+
+    tempdir = tempfile.mkdtemp(prefix='devlib-test-')
+    for key, value in data.items():
+        path = os.path.join(tempdir, key)
+        with open(path, 'w', encoding='utf-8') as wfh:
+            wfh.write(value)
+
+    raw_result = target.read_tree_values_flat(tempdir)
+    result = {os.path.basename(k): v for k, v in raw_result.items()}
+
+    shutil.rmtree(tempdir)
+
+    assert {k: v.strip() for k, v in data.items()} == result


### PR DESCRIPTION
**Commits:**
1. [utils/android: Add debug log about connection settings](https://github.com/ARM-software/devlib/pull/670/commits/2169e61)
1. [utils/misc: Move load_struct_from_yaml() from WA to devlib](https://github.com/ARM-software/devlib/pull/670/commits/fb8887f)
1. [tests/test_target: Read target connection settings from a YAML file](https://github.com/ARM-software/devlib/pull/670/commits/6217c77)

---

### PRs https://github.com/ARM-software/devlib/pull/667 and https://github.com/ARM-software/workload-automation/pull/1248  can be merged after this one.