### PR TITLE
Validate cgroups_run_into has taken effect

### DIFF
--- a/devlib/bin/scripts/shutils.in
+++ b/devlib/bin/scripts/shutils.in
@@ -154,7 +154,16 @@ cgroups_run_into() {
 		# Move this shell into that control group
 		echo $$ > $CGPATH/cgroup.procs
 		echo "Moving task into root CGroup ($CGPATH)"
+		# Check the move actually worked
+		$GREP -E "$$" $CGPATH/cgroup.procs >/dev/null 2>&1
+		if [ $? -ne 0 ]; then
+			echo "ERROR: Process was not moved into $CGP"
+			exit 1
+	  	fi
 	  done
+	  if [ $? -ne 0 ]; then
+		exit 1
+	  fi
 
 	# Execution under specified CGroup
 	else
@@ -173,8 +182,16 @@ cgroups_run_into() {
 		  # Move this shell into that control group
 		  echo $$ > $CGPATH/cgroup.procs
 		  echo "Moving task into $CGPATH"
+		  # Check the move actually worked
+		  $GREP -E "$$" $CGPATH/cgroup.procs >/dev/null 2>&1
+		  if [ $? -ne 0 ]; then
+			echo "ERROR: Process was not moved into $CGP"
+			exit 1
+	  	  fi
 	  done
-
+	  if [ $? -ne 0 ]; then
+		exit 1
+	  fi
 	fi
 
 	# Execute the command


### PR DESCRIPTION
On some systems this seems to have no effect, leaving the executed shell in the root cgroup. Before, this function would still execute and the end user would think the desired process was run in the cgroup when infact it had not.