### PR TITLE
Fix BackgroundCommand.send_signal() and add trace-cmd record support

### DIFF
--- a/devlib/bin/scripts/devlib-signal-target
+++ b/devlib/bin/scripts/devlib-signal-target
@@ -1,0 +1,20 @@
+(
+    # If there is no data dir, it means we are not running as a background
+    # command so we just do nothing
+    if [ -e "$_DEVLIB_BG_CMD_DATA_DIR" ]; then
+        pid_file="$_DEVLIB_BG_CMD_DATA_DIR/pid"
+        # Atomically check if the PID file already exist and make the write
+        # fail if it already does. This way we don't have any race condition
+        # with the Python API, as there is either no PID or the same PID for
+        # the duration of the command
+        set -o noclobber
+        if ! printf "%u\n" $$ > "$pid_file"; then
+            echo "$0 was already called for this command" >&2
+            exit 1
+        fi
+    fi
+) || exit $?
+
+# Use exec so that the PID of the command we run is the same as the current $$
+# PID that we just registered
+exec "$@"

--- a/devlib/collector/ftrace.py
+++ b/devlib/collector/ftrace.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import contextlib
 from shlex import quote
+import signal
 
 from devlib.collector import (CollectorBase, CollectorOutput,
                               CollectorOutputEntry)
@@ -71,6 +72,7 @@ class FtraceCollector(CollectorBase):
                  report_on_target=False,
                  trace_clock='local',
                  saved_cmdlines_nr=4096,
+                 mode='write-to-memory',
                  ):
         super(FtraceCollector, self).__init__(target)
         self.events = events if events is not None else DEFAULT_EVENTS
@@ -98,6 +100,8 @@ class FtraceCollector(CollectorBase):
         self.trace_clock = trace_clock
         self.saved_cmdlines_nr = saved_cmdlines_nr
         self._reset_needed = True
+        self.mode = mode
+        self._bg_cmd = None
 
         # pylint: disable=bad-whitespace
         # Setup tracing paths
@@ -288,18 +292,33 @@ class FtraceCollector(CollectorBase):
         with contextlib.suppress(TargetStableError):
             self.target.write_value('/proc/sys/kernel/kptr_restrict', 0)
 
-        self.target.execute(
-            '{} start -B devlib {buffer_size} {cmdlines_size} {clock} {events} {tracer} {functions}'.format(
-                self.target_binary,
-                events=self.event_string,
-                tracer=tracer_string,
-                functions=tracecmd_functions,
-                buffer_size='-b {}'.format(self.buffer_size) if self.buffer_size is not None else '',
-                clock='-C {}'.format(self.trace_clock) if self.trace_clock else '',
-                cmdlines_size='--cmdlines-size {}'.format(self.saved_cmdlines_nr) if self.saved_cmdlines_nr is not None else '',
-            ),
-            as_root=True,
+        params = '-B devlib {buffer_size} {cmdlines_size} {clock} {events} {tracer} {functions}'.format(
+            events=self.event_string,
+            tracer=tracer_string,
+            functions=tracecmd_functions,
+            buffer_size='-b {}'.format(self.buffer_size) if self.buffer_size is not None else '',
+            clock='-C {}'.format(self.trace_clock) if self.trace_clock else '',
+            cmdlines_size='--cmdlines-size {}'.format(self.saved_cmdlines_nr) if self.saved_cmdlines_nr is not None else '',
         )
+
+        mode = self.mode
+        if mode == 'write-to-disk':
+            bg_cmd = self.target.background(
+                # cd into the working_directory first to workaround this issue:
+                # https://lore.kernel.org/linux-trace-devel/20240119162743.1a107fa9@gandalf.local.home/
+                f'cd {self.target.working_directory} && devlib-signal-target {self.target_binary} record -o {quote(self.target_output_file)} {params}',
+                as_root=True,
+            )
+            assert self._bg_cmd is None
+            self._bg_cmd = bg_cmd.__enter__()
+        elif mode == 'write-to-memory':
+            self.target.execute(
+                f'{self.target_binary} start {params}',
+                as_root=True,
+            )
+        else:
+            raise ValueError(f'Unknown mode {mode}')
+
         if self.automark:
             self.mark_start()
         if 'cpufreq' in self.target.modules:
@@ -334,8 +353,21 @@ class FtraceCollector(CollectorBase):
         self.stop_time = time.time()
         if self.automark:
             self.mark_stop()
-        self.target.execute('{} stop -B devlib'.format(self.target_binary),
-                            timeout=TIMEOUT, as_root=True)
+
+        mode = self.mode
+        if mode == 'write-to-disk':
+            bg_cmd = self._bg_cmd
+            self._bg_cmd = None
+            assert bg_cmd is not None
+            bg_cmd.send_signal(signal.SIGINT)
+            bg_cmd.communicate()
+            bg_cmd.__exit__(None, None, None)
+        elif mode == 'write-to-memory':
+            self.target.execute('{} stop -B devlib'.format(self.target_binary),
+                                timeout=TIMEOUT, as_root=True)
+        else:
+            raise ValueError(f'Unknown mode {mode}')
+
         self._reset_needed = True
 
     def set_output(self, output_path):
@@ -346,9 +378,18 @@ class FtraceCollector(CollectorBase):
     def get_data(self):
         if self.output_path is None:
             raise RuntimeError("Output path was not set.")
-        self.target.execute('{0} extract -B devlib -o {1}; chmod 666 {1}'.format(self.target_binary,
-                                                                       self.target_output_file),
-                            timeout=TIMEOUT, as_root=True)
+
+        busybox = quote(self.target.busybox)
+
+        mode = self.mode
+        if mode == 'write-to-disk':
+            # Interrupting trace-cmd record will make it create the file
+            pass
+        elif mode == 'write-to-memory':
+            cmd = f'{self.target_binary} extract -B devlib -o {self.target_output_file} && {busybox} chmod 666 {self.target_output_file}'
+            self.target.execute(cmd, timeout=TIMEOUT, as_root=True)
+        else:
+            raise ValueError(f'Unknown mode {mode}')
 
         # The size of trace.dat will depend on how long trace-cmd was running.
         # Therefore timout for the pull command must also be adjusted

--- a/devlib/host.py
+++ b/devlib/host.py
@@ -147,16 +147,25 @@ class LocalConnection(ConnectionBase):
         def preexec_fn():
             os.setpgrp()
 
-        popen = subprocess.Popen(
-            command,
-            stdout=stdout,
-            stderr=stderr,
-            stdin=subprocess.PIPE,
-            shell=True,
-            preexec_fn=preexec_fn,
+        def make_init_kwargs(command):
+            popen = subprocess.Popen(
+                command,
+                stdout=stdout,
+                stderr=stderr,
+                stdin=subprocess.PIPE,
+                shell=True,
+                preexec_fn=preexec_fn,
+            )
+            return dict(
+                popen=popen,
+            )
+
+        return PopenBackgroundCommand.from_factory(
+            conn=self,
+            cmd=command,
+            as_root=as_root,
+            make_init_kwargs=make_init_kwargs,
         )
-        bg_cmd = PopenBackgroundCommand(self, popen)
-        return bg_cmd
 
     def _close(self):
         pass

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -320,6 +320,7 @@ class Target(object):
                  conn_cls=None,
                  is_container=False,
                  max_async=50,
+                 tmp_directory=None,
                  ):
 
         self._lock = threading.RLock()
@@ -347,6 +348,7 @@ class Target(object):
         self.connection_settings['platform'] = self.platform
         self.working_directory = working_directory
         self.executables_directory = executables_directory
+        self.tmp_directory = tmp_directory
         self.load_default_modules = load_default_modules
         self.shell_prompt = bytes_regex(shell_prompt)
         self.conn_cls = conn_cls
@@ -356,7 +358,6 @@ class Target(object):
         self._installed_modules = {}
         self._cache = {}
         self._shutils = None
-        self._file_transfer_cache = None
         self._max_async = max_async
         self.busybox = None
 
@@ -477,10 +478,35 @@ class Target(object):
             self.wait_boot_complete(timeout)
         self.check_connection()
         self._resolve_paths()
-        self.execute('mkdir -p {}'.format(quote(self.working_directory)))
-        self.execute('mkdir -p {}'.format(quote(self.executables_directory)))
+        assert self.working_directory
+        if self.executables_directory is None:
+            self.executables_directory = self.path.join(
+                self.working_directory,
+                'bin'
+            )
+
+        for path in (self.working_directory, self.executables_directory):
+            self.makedirs(path)
+
         self.busybox = self.install(os.path.join(PACKAGE_BIN_DIRECTORY, self.abi, 'busybox'), timeout=30)
         self.conn.busybox = self.busybox
+
+        # If neither the mktemp call nor _resolve_paths() managed to get a
+        # temporary directory, we just make one in the working directory.
+        if self.tmp_directory is None:
+            assert self.busybox
+            try:
+                tmp = await self.execute.asyn(f'{quote(self.busybox)} mktemp -d')
+            except Exception:
+                # Some Android platforms don't have a working mktemp unless
+                # TMPDIR is set, so we let AndroidTarget._resolve_paths() deal
+                # with finding a suitable location.
+                tmp = self.path.join(self.working_directory, 'tmp')
+            else:
+                tmp = tmp.strip()
+            self.tmp_directory = tmp
+        self.makedirs(self.tmp_directory)
+
         self._detect_max_async(max_async or self._max_async)
         self.platform.update_from_target(self)
         self._update_modules('connected')
@@ -602,8 +628,6 @@ class Target(object):
         # Initialize modules which requires Busybox (e.g. shutil dependent tasks)
         self._update_modules('setup')
 
-        await self.execute.asyn('mkdir -p {}'.format(quote(self._file_transfer_cache)))
-
     def reboot(self, hard=False, connect=True, timeout=180):
         if hard:
             if not self.has('hard_reset'):
@@ -637,24 +661,11 @@ class Target(object):
         Context manager to provide a unique path in the transfer cache with the
         basename of the given name.
         """
-        # Use a UUID to avoid race conditions on the target side
-        xfer_uuid = uuid.uuid4().hex
-        folder = self.path.join(self._file_transfer_cache, xfer_uuid)
         # Make sure basename will work on folders too
         name = os.path.normpath(name)
-        # Ensure the name is relative so that os.path.join() will actually
-        # join the paths rather than ignoring the first one.
-        name = './{}'.format(os.path.basename(name))
-
-        check_rm = False
-        try:
-            await self.makedirs.asyn(folder)
-            # Don't check the exit code as the folder might not even exist
-            # before this point, if creating it failed
-            check_rm = True
-            yield self.path.join(folder, name)
-        finally:
-            await self.execute.asyn('rm -rf -- {}'.format(quote(folder)), check_exit_code=check_rm)
+        name = os.path.basename(name)
+        async with self.make_temp() as tmp:
+            yield self.path.join(tmp, name)
 
     @asyn.asyncf
     async def _prepare_xfer(self, action, sources, dest, pattern=None, as_root=False):
@@ -944,15 +955,17 @@ class Target(object):
     # execution
 
     def _prepare_cmd(self, command, force_locale):
+        tmpdir = f'TMPDIR={quote(self.tmp_directory)}' if self.tmp_directory else ''
+
         # Force the locale if necessary for more predictable output
         if force_locale:
             # Use an explicit export so that the command is allowed to be any
             # shell statement, rather than just a command invocation
-            command = 'export LC_ALL={} && {}'.format(quote(force_locale), command)
+            command = f'export LC_ALL={quote(force_locale)} {tmpdir} && {command}'
 
         # Ensure to use deployed command when availables
         if self.executables_directory:
-            command = "export PATH={}:$PATH && {}".format(quote(self.executables_directory), command)
+            command = f"export PATH={quote(self.executables_directory)}:$PATH && {command}"
 
         return command
 
@@ -1778,6 +1791,7 @@ class LinuxTarget(Target):
                  conn_cls=SshConnection,
                  is_container=False,
                  max_async=50,
+                 tmp_directory=None,
                  ):
         super(LinuxTarget, self).__init__(connection_settings=connection_settings,
                                           platform=platform,
@@ -1789,7 +1803,9 @@ class LinuxTarget(Target):
                                           shell_prompt=shell_prompt,
                                           conn_cls=conn_cls,
                                           is_container=is_container,
-                                          max_async=max_async)
+                                          max_async=max_async,
+                                          tmp_directory=tmp_directory,
+                                          )
 
     def wait_boot_complete(self, timeout=10):
         pass
@@ -1871,10 +1887,8 @@ class LinuxTarget(Target):
 
     def _resolve_paths(self):
         if self.working_directory is None:
+            # This usually lands in the home directory
             self.working_directory = self.path.join(self.execute("pwd").strip(), 'devlib-target')
-        self._file_transfer_cache = self.path.join(self.working_directory, '.file-cache')
-        if self.executables_directory is None:
-            self.executables_directory = self.path.join(self.working_directory, 'bin')
 
 
 class AndroidTarget(Target):
@@ -1989,6 +2003,7 @@ class AndroidTarget(Target):
                  package_data_directory="/data/data",
                  is_container=False,
                  max_async=50,
+                 tmp_directory=None,
                  ):
         super(AndroidTarget, self).__init__(connection_settings=connection_settings,
                                             platform=platform,
@@ -2000,7 +2015,9 @@ class AndroidTarget(Target):
                                             shell_prompt=shell_prompt,
                                             conn_cls=conn_cls,
                                             is_container=is_container,
-                                            max_async=max_async)
+                                            max_async=max_async,
+                                            tmp_directory=tmp_directory,
+                                            )
         self.package_data_directory = package_data_directory
         self._init_logcat_lock()
 
@@ -2590,9 +2607,16 @@ class AndroidTarget(Target):
     def _resolve_paths(self):
         if self.working_directory is None:
             self.working_directory = self.path.join(self.external_storage, 'devlib-target')
-        self._file_transfer_cache = self.path.join(self.working_directory, '.file-cache')
+        if self.tmp_directory is None:
+            # Do not rely on the generic default here, as we need to provide an
+            # android-specific default in case it fails.
+            try:
+                tmp = self.execute(f'{quote(self.busybox)} mktemp -d')
+            except Exception:
+                tmp = '/data/local/tmp'
+            self.tmp_directory = tmp
         if self.executables_directory is None:
-            self.executables_directory = '/data/local/tmp/bin'
+            self.executables_directory = self.path.join(self.tmp_directory, 'bin')
 
     @asyn.asyncf
     async def _ensure_executables_directory_is_writable(self):
@@ -3067,6 +3091,7 @@ class LocalLinuxTarget(LinuxTarget):
                  conn_cls=LocalConnection,
                  is_container=False,
                  max_async=50,
+                 tmp_directory=None,
                  ):
         super(LocalLinuxTarget, self).__init__(connection_settings=connection_settings,
                                                platform=platform,
@@ -3078,14 +3103,13 @@ class LocalLinuxTarget(LinuxTarget):
                                                shell_prompt=shell_prompt,
                                                conn_cls=conn_cls,
                                                is_container=is_container,
-                                               max_async=max_async)
+                                               max_async=max_async,
+                                               tmp_directory=tmp_directory,
+                                               )
 
     def _resolve_paths(self):
         if self.working_directory is None:
             self.working_directory = '/tmp/devlib-target'
-        self._file_transfer_cache = self.path.join(self.working_directory, '.file-cache')
-        if self.executables_directory is None:
-            self.executables_directory = '/tmp/devlib-target/bin'
 
 
 def _get_model_name(section):
@@ -3156,6 +3180,7 @@ class ChromeOsTarget(LinuxTarget):
                  package_data_directory="/data/data",
                  is_container=False,
                  max_async=50,
+                 tmp_directory=None,
                  ):
 
         self.supports_android = None
@@ -3184,7 +3209,9 @@ class ChromeOsTarget(LinuxTarget):
             shell_prompt=shell_prompt,
             conn_cls=SshConnection,
             is_container=is_container,
-            max_async=max_async)
+            max_async=max_async,
+            tmp_directory=tmp_directory,
+            )
 
         # We can't determine if the target supports android until connected to the linux host so
         # create unconditionally.
@@ -3246,6 +3273,3 @@ class ChromeOsTarget(LinuxTarget):
     def _resolve_paths(self):
         if self.working_directory is None:
             self.working_directory = '/mnt/stateful_partition/devlib-target'
-        self._file_transfer_cache = self.path.join(self.working_directory, '.file-cache')
-        if self.executables_directory is None:
-            self.executables_directory = self.path.join(self.working_directory, 'bin')

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1310,8 +1310,10 @@ fi
         return self.path.join(self.working_directory, name)
 
     @asyn.asyncf
-    async def tempfile(self, prefix='', suffix=''):
-        name = '{prefix}_{uuid}_{suffix}'.format(
+    async def tempfile(self, prefix=None, suffix=None):
+        prefix = f'{prefix}-' if prefix else ''
+        suffix = f'-{suffix}' if suffix else ''
+        name = '{prefix}{uuid}{suffix}'.format(
             prefix=prefix,
             uuid=uuid.uuid4().hex,
             suffix=suffix,

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1191,7 +1191,7 @@ fi
                 raise
 
     @asyn.asynccontextmanager
-    async def make_temp(self, is_directory=True, directory='', prefix='devlib-test'):
+    async def make_temp(self, is_directory=True, directory=None, prefix=None):
         """
         Creates temporary file/folder on target and deletes it once it's done.
 
@@ -1209,10 +1209,11 @@ fi
         :rtype: str
         """
 
-        directory = directory or self.working_directory
+        directory = directory or self.tmp_directory
+        prefix = f'{prefix}-' if prefix else ''
         temp_obj = None
         try:
-            cmd = f'mktemp -p {quote(directory)} {quote(prefix)}-XXXXXX'
+            cmd = f'mktemp -p {quote(directory)} {quote(prefix)}XXXXXX'
             if is_directory:
                 cmd += ' -d'
 

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1876,12 +1876,11 @@ class LinuxTarget(Target):
             return
         try:
 
-            tmpfile = await self.tempfile.asyn()
-            cmd = 'DISPLAY=:0.0 scrot {} && {} date -u -Iseconds'
-            ts = (await self.execute.asyn(cmd.format(quote(tmpfile), quote(self.busybox)))).strip()
-            filepath = filepath.format(ts=ts)
-            await self.pull.asyn(tmpfile, filepath)
-            await self.remove.asyn(tmpfile)
+            async with self.make_temp(is_directory=False) as tmpfile:
+                cmd = 'DISPLAY=:0.0 scrot {} && {} date -u -Iseconds'
+                ts = (await self.execute.asyn(cmd.format(quote(tmpfile), quote(self.busybox)))).strip()
+                filepath = filepath.format(ts=ts)
+                await self.pull.asyn(tmpfile, filepath)
         except TargetStableError as e:
             if "Can't open X dispay." not in e.message:
                 raise e

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -281,7 +281,7 @@ class Target(object):
     @property
     def shutils(self):
         if self._shutils is None:
-            self._setup_shutils()
+            self._setup_scripts()
         return self._shutils
 
     def is_running(self, comm):
@@ -591,7 +591,7 @@ class Target(object):
 
     @asyn.asyncf
     async def setup(self, executables=None):
-        await self._setup_shutils.asyn()
+        await self._setup_scripts.asyn()
 
         for host_exe in (executables or []):  # pylint: disable=superfluous-parens
             await self.install.asyn(host_exe)
@@ -1562,8 +1562,9 @@ fi
     # internal methods
 
     @asyn.asyncf
-    async def _setup_shutils(self):
-        shutils_ifile = os.path.join(PACKAGE_BIN_DIRECTORY, 'scripts', 'shutils.in')
+    async def _setup_scripts(self):
+        scripts = os.path.join(PACKAGE_BIN_DIRECTORY, 'scripts')
+        shutils_ifile = os.path.join(scripts, 'shutils.in')
         with open(shutils_ifile) as fh:
             lines = fh.readlines()
         with tempfile.TemporaryDirectory() as folder:
@@ -1573,6 +1574,8 @@ fi
                     line = line.replace("__DEVLIB_BUSYBOX__", self.busybox)
                     ofile.write(line)
             self._shutils = await self.install.asyn(shutils_ofile)
+
+        await self.install.asyn(os.path.join(scripts, 'devlib-signal-target'))
 
     @asyn.asyncf
     @call_conn

--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1316,7 +1316,7 @@ fi
             uuid=uuid.uuid4().hex,
             suffix=suffix,
         )
-        path = self.get_workpath(name)
+        path = self.path.join(self.tmp_directory, name)
         if (await self.file_exists.asyn(path)):
             raise FileExistsError('Path already exists on the target: {}'.format(path))
         else:

--- a/devlib/utils/android.py
+++ b/devlib/utils/android.py
@@ -40,7 +40,7 @@ from shlex import quote
 
 from devlib.exception import TargetTransientError, TargetStableError, HostError, TargetTransientCalledProcessError, TargetStableCalledProcessError, AdbRootError
 from devlib.utils.misc import check_output, which, ABI_MAP, redirect_streams, get_subprocess
-from devlib.connection import ConnectionBase, AdbBackgroundCommand, PopenBackgroundCommand, PopenTransferHandle
+from devlib.connection import ConnectionBase, AdbBackgroundCommand, PopenTransferHandle
 
 
 logger = logging.getLogger('android')
@@ -341,7 +341,7 @@ class AdbConnection(ConnectionBase):
         if timeout:
             adb_command(self.device, command, timeout=timeout, adb_server=self.adb_server, adb_port=self.adb_port)
         else:
-            bg_cmd = adb_command_background(
+            popen = adb_command_popen(
                 device=self.device,
                 conn=self,
                 command=command,
@@ -351,12 +351,12 @@ class AdbConnection(ConnectionBase):
 
             handle = PopenTransferHandle(
                 manager=self.transfer_manager,
-                bg_cmd=bg_cmd,
+                popen=popen,
                 dest=dest,
                 direction=action
             )
-            with bg_cmd, self.transfer_manager.manage(sources, dest, action, handle):
-                bg_cmd.communicate()
+            with popen, self.transfer_manager.manage(sources, dest, action, handle):
+                popen.communicate()
 
     # pylint: disable=unused-argument
     def execute(self, command, timeout=None, check_exit_code=False,
@@ -387,12 +387,18 @@ class AdbConnection(ConnectionBase):
         return bg_cmd
 
     def _background(self, command, stdout, stderr, as_root):
-        adb_shell, pid = adb_background_shell(self, command, stdout, stderr, as_root)
-        bg_cmd = AdbBackgroundCommand(
+        def make_init_kwargs(command):
+            adb_popen, pid = adb_background_shell(self, command, stdout, stderr, as_root)
+            return dict(
+                adb_popen=adb_popen,
+                pid=pid,
+            )
+
+        bg_cmd = AdbBackgroundCommand.from_factory(
             conn=self,
-            adb_popen=adb_shell,
-            pid=pid,
-            as_root=as_root
+            cmd=command,
+            as_root=as_root,
+            make_init_kwargs=make_init_kwargs,
         )
         return bg_cmd
 
@@ -756,12 +762,11 @@ def adb_command(device, command, timeout=None, adb_server=None, adb_port=None):
     return output
 
 
-def adb_command_background(device, conn, command, adb_server=None, adb_port=None):
-    full_command = get_adb_command(device, command, adb_server, adb_port)
-    logger.debug(full_command)
-    popen = get_subprocess(full_command, shell=True)
-    cmd = PopenBackgroundCommand(conn=conn, popen=popen)
-    return cmd
+def adb_command_popen(device, conn, command, adb_server=None, adb_port=None):
+    command = get_adb_command(device, command, adb_server, adb_port)
+    logger.debug(command)
+    popen = get_subprocess(command, shell=True)
+    return popen
 
 
 def grant_app_permissions(target, package):

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -602,138 +602,142 @@ class SshConnection(SshConnectionBase):
             return self._background(command, stdout, stderr, as_root)
 
     def _background(self, command, stdout, stderr, as_root):
-        orig_command = command
-        stdout, stderr, command = redirect_streams(stdout, stderr, command)
+        def make_init_kwargs(command):
+            _stdout, _stderr, _command = redirect_streams(stdout, stderr, command)
 
-        command = "printf '%s\n' $$; exec sh -c {}".format(quote(command))
-        channel = self._make_channel()
+            _command = "printf '%s\n' $$; exec sh -c {}".format(quote(_command))
+            channel = self._make_channel()
 
-        def executor(cmd, timeout):
-            channel.exec_command(cmd)
-            # Read are not buffered so we will always get the data as soon as
-            # they arrive
-            return (
-                channel.makefile_stdin('w', 0),
-                channel.makefile(),
-                channel.makefile_stderr(),
+            def executor(cmd, timeout):
+                channel.exec_command(cmd)
+                # Read are not buffered so we will always get the data as soon as
+                # they arrive
+                return (
+                    channel.makefile_stdin('w', 0),
+                    channel.makefile(),
+                    channel.makefile_stderr(),
+                )
+
+            stdin, stdout_in, stderr_in = self._execute_command(
+                _command,
+                as_root=as_root,
+                log=False,
+                timeout=None,
+                executor=executor,
             )
+            pid = stdout_in.readline()
+            if not pid:
+                _stderr = stderr_in.read()
+                if channel.exit_status_ready():
+                    ret = channel.recv_exit_status()
+                else:
+                    ret = 126
+                raise subprocess.CalledProcessError(
+                    ret,
+                    _command,
+                    b'',
+                    _stderr,
+                )
+            pid = int(pid)
 
-        stdin, stdout_in, stderr_in = self._execute_command(
-            command,
-            as_root=as_root,
-            log=False,
-            timeout=None,
-            executor=executor,
-        )
-        pid = stdout_in.readline()
-        if not pid:
-            stderr = stderr_in.read()
-            if channel.exit_status_ready():
-                ret = channel.recv_exit_status()
-            else:
-                ret = 126
-            raise subprocess.CalledProcessError(
-                ret,
-                command,
-                b'',
-                stderr,
-            )
-        pid = int(pid)
+            def create_out_stream(stream_in, stream_out):
+                """
+                Create a pair of file-like objects. The first one is used to read
+                data and the second one to write.
+                """
 
-        def create_out_stream(stream_in, stream_out):
-            """
-            Create a pair of file-like objects. The first one is used to read
-            data and the second one to write.
-            """
+                if stream_out == subprocess.DEVNULL:
+                    r, w = None, None
+                # When asked for a pipe, we just give the file-like object as the
+                # reading end and no writing end, since paramiko already writes to
+                # it
+                elif stream_out == subprocess.PIPE:
+                    r, w = os.pipe()
+                    r = os.fdopen(r, 'rb')
+                    w = os.fdopen(w, 'wb')
+                # Turn a file descriptor into a file-like object
+                elif isinstance(stream_out, int) and stream_out >= 0:
+                    r = os.fdopen(stream_in, 'rb')
+                    w = os.fdopen(stream_out, 'wb')
+                # file-like object
+                else:
+                    r = stream_in
+                    w = stream_out
 
-            if stream_out == subprocess.DEVNULL:
-                r, w = None, None
-            # When asked for a pipe, we just give the file-like object as the
-            # reading end and no writing end, since paramiko already writes to
-            # it
-            elif stream_out == subprocess.PIPE:
-                r, w = os.pipe()
-                r = os.fdopen(r, 'rb')
-                w = os.fdopen(w, 'wb')
-            # Turn a file descriptor into a file-like object
-            elif isinstance(stream_out, int) and stream_out >= 0:
-                r = os.fdopen(stream_in, 'rb')
-                w = os.fdopen(stream_out, 'wb')
-            # file-like object
-            else:
-                r = stream_in
-                w = stream_out
+                return (r, w)
 
-            return (r, w)
+            out_streams = {
+                name: create_out_stream(stream_in, stream_out)
+                for stream_in, stream_out, name in (
+                    (stdout_in, _stdout, 'stdout'),
+                    (stderr_in, _stderr, 'stderr'),
+                )
+            }
 
-        out_streams = {
-            name: create_out_stream(stream_in, stream_out)
-            for stream_in, stream_out, name in (
-                (stdout_in, stdout, 'stdout'),
-                (stderr_in, stderr, 'stderr'),
-            )
-        }
+            def redirect_thread_f(stdout_in, stderr_in, out_streams, select_timeout):
+                def callback(out_streams, name, chunk):
+                    try:
+                        r, w = out_streams[name]
+                    except KeyError:
+                        return out_streams
 
-        def redirect_thread_f(stdout_in, stderr_in, out_streams, select_timeout):
-            def callback(out_streams, name, chunk):
-                try:
-                    r, w = out_streams[name]
-                except KeyError:
+                    try:
+                        w.write(chunk)
+                    # Write failed
+                    except ValueError:
+                        # Since that stream is now closed, stop trying to write to it
+                        del out_streams[name]
+                        # If that was the last open stream, we raise an
+                        # exception so the thread can terminate.
+                        if not out_streams:
+                            raise
+
                     return out_streams
 
                 try:
-                    w.write(chunk)
-                # Write failed
+                    _read_paramiko_streams(stdout_in, stderr_in, select_timeout, callback, copy.copy(out_streams))
+                # The streams closed while we were writing to it, the job is done here
                 except ValueError:
-                    # Since that stream is now closed, stop trying to write to it
-                    del out_streams[name]
-                    # If that was the last open stream, we raise an
-                    # exception so the thread can terminate.
-                    if not out_streams:
-                        raise
+                    pass
 
-                return out_streams
+                # Make sure the writing end are closed proper since we are not
+                # going to write anything anymore
+                for r, w in out_streams.values():
+                    w.flush()
+                    if r is not w and w is not None:
+                        w.close()
 
-            try:
-                _read_paramiko_streams(stdout_in, stderr_in, select_timeout, callback, copy.copy(out_streams))
-            # The streams closed while we were writing to it, the job is done here
-            except ValueError:
-                pass
+            # If there is anything we need to redirect to, spawn a thread taking
+            # care of that
+            select_timeout = 1
+            thread_out_streams = {
+                name: (r, w)
+                for name, (r, w) in out_streams.items()
+                if w is not None
+            }
+            redirect_thread = threading.Thread(
+                target=redirect_thread_f,
+                args=(stdout_in, stderr_in, thread_out_streams, select_timeout),
+                # The thread will die when the main thread dies
+                daemon=True,
+            )
+            redirect_thread.start()
 
-            # Make sure the writing end are closed proper since we are not
-            # going to write anything anymore
-            for r, w in out_streams.values():
-                w.flush()
-                if r is not w and w is not None:
-                    w.close()
+            return dict(
+                chan=channel,
+                pid=pid,
+                stdin=stdin,
+                # We give the reading end to the consumer of the data
+                stdout=out_streams['stdout'][0],
+                stderr=out_streams['stderr'][0],
+                redirect_thread=redirect_thread,
+            )
 
-        # If there is anything we need to redirect to, spawn a thread taking
-        # care of that
-        select_timeout = 1
-        thread_out_streams = {
-            name: (r, w)
-            for name, (r, w) in out_streams.items()
-            if w is not None
-        }
-        redirect_thread = threading.Thread(
-            target=redirect_thread_f,
-            args=(stdout_in, stderr_in, thread_out_streams, select_timeout),
-            # The thread will die when the main thread dies
-            daemon=True,
-        )
-        redirect_thread.start()
-
-        return ParamikoBackgroundCommand(
+        return ParamikoBackgroundCommand.from_factory(
             conn=self,
+            cmd=command,
             as_root=as_root,
-            chan=channel,
-            pid=pid,
-            stdin=stdin,
-            # We give the reading end to the consumer of the data
-            stdout=out_streams['stdout'][0],
-            stderr=out_streams['stderr'][0],
-            redirect_thread=redirect_thread,
-            cmd=orig_command,
+            make_init_kwargs=make_init_kwargs,
         )
 
     def _close(self):


### PR DESCRIPTION
Fixes https://github.com/ARM-software/devlib/issues/645
Supersedes https://github.com/ARM-software/devlib/pull/643

TODO:
* [ ] Add/update docstrings
* [x] Figure out if moving some init logic for the various subclasses of BackgroundCommand inside the class would simplify the code and avoid BackgroundCommand.from_factory() layer.

Closes https://github.com/ARM-software/devlib/pull/643