### PR TITLE
utils/misc: Fix AttributeError in tls_property

### DIFF
--- a/devlib/utils/misc.py
+++ b/devlib/utils/misc.py
@@ -842,8 +842,13 @@ class tls_property:
     def __delete__(self, instance):
         tls, values = self._get_tls(instance)
         with self.lock:
-            values.discard(tls.value)
-        del tls.value
+            try:
+                value = tls.value
+            except AttributeError:
+                pass
+            else:
+                values.discard(value)
+                del tls.value
 
     def _get_tls(self, instance):
         dct = instance.__dict__


### PR DESCRIPTION
Do not assume the value of the property was set before it is deleted.