### PR TITLE
target: Properly propagate ADB port information

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1904,6 +1904,10 @@ class AndroidTarget(Target):
         return getattr(self.conn, 'adb_server', None)
 
     @property
+    def adb_port(self):
+        return getattr(self.conn, 'adb_port', None)
+
+    @property
     @memoized
     def android_id(self):
         """
@@ -2240,8 +2244,10 @@ class AndroidTarget(Target):
                 flags.append('-g')  # Grant all runtime permissions
             self.logger.debug("Replace APK = {}, ADB flags = '{}'".format(replace, ' '.join(flags)))
             if isinstance(self.conn, AdbConnection):
-                return adb_command(self.adb_name, "install {} {}".format(' '.join(flags), quote(filepath)),
-                                   timeout=timeout, adb_server=self.adb_server)
+                return adb_command(self.adb_name,
+                                   "install {} {}".format(' '.join(flags), quote(filepath)),
+                                   timeout=timeout, adb_server=self.adb_server,
+                                   adb_port=self.adb_port)
             else:
                 dev_path = self.get_workpath(filepath.rsplit(os.path.sep, 1)[-1])
                 await self.push.asyn(quote(filepath), dev_path, timeout=timeout)
@@ -2319,7 +2325,7 @@ class AndroidTarget(Target):
     async def uninstall_package(self, package):
         if isinstance(self.conn, AdbConnection):
             adb_command(self.adb_name, "uninstall {}".format(quote(package)), timeout=30,
-                        adb_server=self.adb_server)
+                        adb_server=self.adb_server, adb_port=self.adb_port)
         else:
             await self.execute.asyn("pm uninstall {}".format(quote(package)), timeout=30)
 
@@ -2338,7 +2344,8 @@ class AndroidTarget(Target):
         logcat_opts = '-d' + formatstr + filtstr
         if isinstance(self.conn, AdbConnection):
             command = 'logcat {} {} {}'.format(logcat_opts, op, quote(filepath))
-            adb_command(self.adb_name, command, timeout=timeout, adb_server=self.adb_server)
+            adb_command(self.adb_name, command, timeout=timeout, adb_server=self.adb_server,
+                        adb_port=self.adb_port)
         else:
             dev_path = self.get_workpath('logcat')
             command = 'logcat {} {} {}'.format(logcat_opts, op, quote(dev_path))
@@ -2352,7 +2359,8 @@ class AndroidTarget(Target):
         if locked:
             try:
                 if isinstance(self.conn, AdbConnection):
-                    adb_command(self.adb_name, 'logcat -c', timeout=30, adb_server=self.adb_server)
+                    adb_command(self.adb_name, 'logcat -c', timeout=30, adb_server=self.adb_server,
+                                adb_port=self.adb_port)
                 else:
                     await self.execute.asyn('logcat -c', timeout=30)
             finally:
@@ -3154,7 +3162,7 @@ class ChromeOsTarget(LinuxTarget):
         # We can't determine if the target supports android until connected to the linux host so
         # create unconditionally.
         # Pull out adb connection settings
-        adb_conn_params = ['device', 'adb_server', 'timeout']
+        adb_conn_params = ['device', 'adb_server', 'adb_port', 'timeout']
         self.android_connection_settings = {}
         self.android_connection_settings.update(
             (key, value)


### PR DESCRIPTION
Some ADB servers may use non-standard port number. Hence, add 'adb_port' property to AndroidTarget class and pass port number down to adb_command().