### PR TITLE
tools/setup_host.sh: Remove unused package cpu-checker

### DIFF
--- a/tools/android/setup_host.sh
+++ b/tools/android/setup_host.sh
@@ -187,7 +187,6 @@ install_pacman() {
 
 # APT-based distributions like Ubuntu or Debian
 apt_packages=(
-    cpu-checker
     libarchive-tools
     qemu-user-static
     wget


### PR DESCRIPTION
`cpu-checker` was planned to detect availability of KVM acceleration in QEMU by running `kvm-ok` command.
However, the implementation diverged from plan and made `cpu-checker` redundant.
Thus, remove it from apt package list.