### PR TITLE
ftrace: Preserve kprobe events during trace-cmd reset

### DIFF
--- a/devlib/collector/ftrace.py
+++ b/devlib/collector/ftrace.py
@@ -107,7 +107,8 @@ class FtraceCollector(CollectorBase):
         self.function_profile_file    = self.target.path.join(self.tracing_path, 'function_profile_enabled')
         self.marker_file              = self.target.path.join(self.tracing_path, 'trace_marker')
         self.ftrace_filter_file       = self.target.path.join(self.tracing_path, 'set_ftrace_filter')
-        self.available_tracers_file  = self.target.path.join(self.tracing_path, 'available_tracers')
+        self.available_tracers_file   = self.target.path.join(self.tracing_path, 'available_tracers')
+        self.kprobe_events            = self.target.path.join(self.tracing_path, 'kprobe_events')
 
         self.host_binary = which('trace-cmd')
         self.kernelshark = which('kernelshark')
@@ -240,6 +241,9 @@ class FtraceCollector(CollectorBase):
         return self.target.read_value(self.available_functions_file).splitlines()
 
     def reset(self):
+        # Save kprobe events
+        kprobe_events = self.target.read_value(self.kprobe_events)
+
         self.target.execute('{} reset -B devlib'.format(self.target_binary),
                             as_root=True, timeout=TIMEOUT)
 
@@ -256,6 +260,10 @@ class FtraceCollector(CollectorBase):
 
         if self.functions:
             self.target.write_value(self.function_profile_file, 0, verify=False)
+
+        # Restore kprobe events
+        self.target.write_value(self.kprobe_events, kprobe_events)
+
         self._reset_needed = False
 
     @asyncf


### PR DESCRIPTION
FtraceCollector.reset() executes 'trace-cmd reset ..' command which
clears all kprobes. This breaks tracing existing kprobe events (if any).
Thus, save kprobe events before trace-cmd reset and restore them after
the reset operation.

For the context, I want to trace an ordinary function in kernel (e.g.,
"echo 'p do_sys_open' > /sys/kernel/tracing/kprobe_events"). However,
FtraceCollector.reset() destroys kprobes, too. Preserving existing
kprobes allows me to use FtraceCollector class as is.

Signed-off-by: Metin Kaya <metin.kaya@arm.com>