### PR TITLE
Fix sudo

### DIFF
--- a/devlib/host.py
+++ b/devlib/host.py
@@ -112,7 +112,9 @@ class LocalConnection(ConnectionBase):
             if self.unrooted:
                 raise TargetStableError('unrooted')
             password = self._get_password()
-            command = "echo {} | sudo -k -p ' ' -S -- sh -c {}".format(quote(password), quote(command))
+            # Empty prompt with -p '' to avoid adding a leading space to the
+            # output.
+            command = "echo {} | sudo -k -p '' -S -- sh -c {}".format(quote(password), quote(command))
         ignore = None if check_exit_code else 'all'
         try:
             stdout, stderr = check_output(command, shell=True, timeout=timeout, ignore=ignore)
@@ -136,9 +138,9 @@ class LocalConnection(ConnectionBase):
             if self.unrooted:
                 raise TargetStableError('unrooted')
             password = self._get_password()
-            # The sudo prompt will add a space on stderr, but we cannot filter
-            # it out here
-            command = "echo {} | sudo -k -p ' ' -S -- sh -c {}".format(quote(password), quote(command))
+            # Empty prompt with -p '' to avoid adding a leading space to the
+            # output.
+            command = "echo {} | sudo -k -p '' -S -- sh -c {}".format(quote(password), quote(command))
 
         # Make sure to get a new PGID so PopenBackgroundCommand() can kill
         # all sub processes that could be started without troubles.

--- a/devlib/utils/ssh.py
+++ b/devlib/utils/ssh.py
@@ -61,7 +61,8 @@ from devlib.utils.types import boolean
 from devlib.connection import ConnectionBase, ParamikoBackgroundCommand, SSHTransferHandle
 
 
-DEFAULT_SSH_SUDO_COMMAND = "sudo -k -p ' ' -S -- sh -c {}"
+# Empty prompt with -p '' to avoid adding a leading space to the output.
+DEFAULT_SSH_SUDO_COMMAND = "sudo -k -p '' -S -- sh -c {}"
 
 
 class _SSHEnv:


### PR DESCRIPTION
Fixes https://github.com/ARM-software/devlib/issues/703

@marcbonnici Can you remember why we used a one-space prompt with `sudo -p ' '` instead of a completely empty prompt ? This prompt seems to be picked up in stdout or stderr when using Target.execute(), modifying the return value as a result.