### PR TITLE
collector/ftrace: Fix FtraceCollector.kprobe_events attr name

### DIFF
--- a/devlib/collector/ftrace.py
+++ b/devlib/collector/ftrace.py
@@ -108,7 +108,7 @@ class FtraceCollector(CollectorBase):
         self.marker_file              = self.target.path.join(self.tracing_path, 'trace_marker')
         self.ftrace_filter_file       = self.target.path.join(self.tracing_path, 'set_ftrace_filter')
         self.available_tracers_file   = self.target.path.join(self.tracing_path, 'available_tracers')
-        self.kprobe_events            = self.target.path.join(self.tracing_path, 'kprobe_events')
+        self.kprobe_events_file       = self.target.path.join(self.tracing_path, 'kprobe_events')
 
         self.host_binary = which('trace-cmd')
         self.kernelshark = which('kernelshark')
@@ -242,7 +242,7 @@ class FtraceCollector(CollectorBase):
 
     def reset(self):
         # Save kprobe events
-        kprobe_events = self.target.read_value(self.kprobe_events)
+        kprobe_events = self.target.read_value(self.kprobe_events_file)
 
         self.target.execute('{} reset -B devlib'.format(self.target_binary),
                             as_root=True, timeout=TIMEOUT)
@@ -262,7 +262,7 @@ class FtraceCollector(CollectorBase):
             self.target.write_value(self.function_profile_file, 0, verify=False)
 
         # Restore kprobe events
-        self.target.write_value(self.kprobe_events, kprobe_events)
+        self.target.write_value(self.kprobe_events_file, kprobe_events)
 
         self._reset_needed = False
 


### PR DESCRIPTION
self.kprobe_events is actually a path to a file, so should be suffixed _file like all the others.