### PR TITLE
collector/ftrace: Handle missing kprobe_events file

### DIFF
--- a/devlib/collector/ftrace.py
+++ b/devlib/collector/ftrace.py
@@ -242,7 +242,10 @@ class FtraceCollector(CollectorBase):
 
     def reset(self):
         # Save kprobe events
-        kprobe_events = self.target.read_value(self.kprobe_events_file)
+        try:
+            kprobe_events = self.target.read_value(self.kprobe_events_file)
+        except TargetStableError:
+            kprobe_events = None
 
         self.target.execute('{} reset -B devlib'.format(self.target_binary),
                             as_root=True, timeout=TIMEOUT)
@@ -262,7 +265,8 @@ class FtraceCollector(CollectorBase):
             self.target.write_value(self.function_profile_file, 0, verify=False)
 
         # Restore kprobe events
-        self.target.write_value(self.kprobe_events_file, kprobe_events)
+        if kprobe_events:
+            self.target.write_value(self.kprobe_events_file, kprobe_events)
 
         self._reset_needed = False
 


### PR DESCRIPTION
Deal cleanly with kernels that are compiled without kprobe events.