### PR TITLE
utils/asyn: Fix cancellation of async tasks in map_concurrently()

### DIFF
--- a/devlib/utils/asyn.py
+++ b/devlib/utils/asyn.py
@@ -123,6 +123,10 @@ class AsyncManager:
         except BaseException:
             for task in tasks:
                 task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
             raise
         finally:
 


### PR DESCRIPTION
Ensure the canceled tasks are awaited, so cancellation actually takes place.