### PR TITLE
Fix make_temp: revert fallback to working_directory

### DIFF
--- a/devlib/target.py
+++ b/devlib/target.py
@@ -1215,7 +1215,7 @@ fi
                 raise
 
     @asyn.asynccontextmanager
-    async def make_temp(self, is_directory=True, directory=None, prefix=None):
+    async def make_temp(self, is_directory=True, directory=None, prefix='devlib-test'):
         """
         Creates temporary file/folder on target and deletes it once it's done.
 
@@ -1233,8 +1233,8 @@ fi
         :rtype: str
         """
 
-        directory = directory or self.tmp_directory
-        prefix = f'{prefix}-' if prefix else ''
+        directory = directory or self.working_directory
+        prefix = f'{prefix}-' if prefix else '-'
         temp_obj = None
         try:
             cmd = f'mktemp -p {quote(directory)} {quote(prefix)}XXXXXX'


### PR DESCRIPTION
This pull request fixes an issue introduced by a recent commit that changed the temporary file creation behavior in make_temp

Previously, make_temp used self.working_directory and a default prefix of 'devlib-test', which provided the necessary permissions for temporary file cleanup. The change to using self.tmp_directory caused permission errors during cleanup and consequently breakages. 

This PR reverts the change by:
- Setting the default prefix to 'devlib-test'
- Reverting the fallback directory from self.tmp_directory back to self.working_directory