### PR TITLE
add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    "setuptools>=80.9.0",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Add a pyproject.toml to devlib.
Since pyproject.toml doesnt directly support dynamic versioning, added only [build-system] section so that tools like pip will refer back to setup.py to install the core of the project
So currently, this has to be used in conjunction with setup.py.

In the future, we can look into fully migrating to a pyproject.toml only approach, but that involves more things to handle versioning. 

Fixes https://github.com/ARM-software/devlib/issues/702